### PR TITLE
Require __GLASGOW_HASKELL__ >= 706 for -XPolyKinds

### DIFF
--- a/0.2/Control/Applicative/Backwards.hs
+++ b/0.2/Control/Applicative/Backwards.hs
@@ -4,7 +4,7 @@
 # if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Safe #-}
 # endif
-# if __GLASGOW_HASKELL__ >= 704
+# if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE PolyKinds #-}
 # endif
 #endif

--- a/0.2/Data/Functor/Reverse.hs
+++ b/0.2/Data/Functor/Reverse.hs
@@ -4,7 +4,7 @@
 # if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Safe #-}
 # endif
-# if __GLASGOW_HASKELL__ >= 704
+# if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE PolyKinds #-}
 # endif
 #endif

--- a/0.3/Control/Monad/Signatures.hs
+++ b/0.3/Control/Monad/Signatures.hs
@@ -4,7 +4,7 @@
 # if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Safe #-}
 # endif
-# if __GLASGOW_HASKELL__ >= 704
+# if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE PolyKinds #-}
 # endif
 #endif

--- a/0.3/Data/Functor/Sum.hs
+++ b/0.3/Data/Functor/Sum.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 # endif
-# if __GLASGOW_HASKELL__ >= 704
+# if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE PolyKinds #-}
 # endif
 # if __GLASGOW_HASKELL__ >= 708

--- a/src/Control/Monad/Trans/Instances.hs
+++ b/src/Control/Monad/Trans/Instances.hs
@@ -14,7 +14,7 @@
 {-# LANGUAGE Trustworthy #-}
 # endif
 
-# if __GLASGOW_HASKELL__ >= 704
+# if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE PolyKinds #-}
 # endif
 


### PR DESCRIPTION
I wasn't aware of [a really nasty GHC 7.4–specific issue](http://hub.darcs.net/ross/transformers/issue/20) involving `-XPolyKinds` until recently. Unfortunately, I backported changes from `transformers-0.5` which use `#if __GLASGOW_HASKELL__ >= 704 {-# LANGUAGE PolyKinds #-} ...`, which means `transformers-compat` is also affected.

This sets things right again. Sorry about the headache...