### PR TITLE
Use generic-deriving for compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,229 +64,58 @@ matrix:
     - env: CABALVER=1.18 GHCVER=7.2.2
       compiler: ": #GHC 7.2.2"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-f-generic-deriving
-      compiler: ": #GHC 7.2.2"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-f-mtl
-      compiler: ": #GHC 7.2.2"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-f-mtl -f-generic-deriving
-      compiler: ": #GHC 7.2.2"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-ftwo
-      compiler: ": #GHC 7.2.2"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-ftwo -f-generic-deriving
-      compiler: ": #GHC 7.2.2"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-ftwo -f-mtl
-      compiler: ": #GHC 7.2.2"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-ftwo -f-generic-deriving -f-mtl
       compiler: ": #GHC 7.2.2"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-fthree
       compiler: ": #GHC 7.2.2"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-fthree -f-generic-deriving
-      compiler: ": #GHC 7.2.2"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-fthree -f-mtl
-      compiler: ": #GHC 7.2.2"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-fthree -f-generic-deriving -f-mtl
-      compiler: ": #GHC 7.2.2"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-ffour
-      compiler: ": #GHC 7.2.2"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-ffour -f-generic-deriving
-      compiler: ": #GHC 7.2.2"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-ffour -f-mtl
-      compiler: ": #GHC 7.2.2"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-ffour -f-generic-deriving -f-mtl
       compiler: ": #GHC 7.2.2"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.4.2
       compiler: ": #GHC 7.4.2"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-f-generic-deriving
-      compiler: ": #GHC 7.4.2"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-f-mtl
-      compiler: ": #GHC 7.4.2"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-f-mtl -f-generic-deriving
-      compiler: ": #GHC 7.4.2"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-ftwo
-      compiler: ": #GHC 7.4.2"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-ftwo -f-generic-deriving
-      compiler: ": #GHC 7.4.2"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-ftwo -f-mtl
-      compiler: ": #GHC 7.4.2"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-ftwo -f-generic-deriving -f-mtl
       compiler: ": #GHC 7.4.2"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-fthree
       compiler: ": #GHC 7.4.2"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-fthree -f-generic-deriving
-      compiler: ": #GHC 7.4.2"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-fthree -f-mtl
-      compiler: ": #GHC 7.4.2"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-fthree -f-generic-deriving -f-mtl
-      compiler: ": #GHC 7.4.2"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-ffour
-      compiler: ": #GHC 7.4.2"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-ffour -f-generic-deriving
-      compiler: ": #GHC 7.4.2"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-ffour -f-mtl
-      compiler: ": #GHC 7.4.2"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-ffour -f-generic-deriving -f-mtl
       compiler: ": #GHC 7.4.2"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.6.3
       compiler: ": #GHC 7.6.3"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-f-generic-deriving
-      compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-f-mtl
-      compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-f-mtl -f-generic-deriving
-      compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-ftwo
-      compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-ftwo -f-generic-deriving
-      compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-ftwo -f-mtl
-      compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-ftwo -f-generic-deriving -f-mtl
       compiler: ": #GHC 7.6.3"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-fthree
       compiler: ": #GHC 7.6.3"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-fthree -f-generic-deriving
-      compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-fthree -f-mtl
-      compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-fthree -f-generic-deriving -f-mtl
-      compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-ffour
-      compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-ffour -f-generic-deriving
-      compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-ffour -f-mtl
-      compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-ffour -f-generic-deriving -f-mtl
       compiler: ": #GHC 7.6.3"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-f-generic-deriving
-      compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-f-mtl
-      compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-f-mtl -f-generic-deriving
-      compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-ftwo
-      compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-ftwo -f-generic-deriving
-      compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-ftwo -f-mtl
-      compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-ftwo -f-generic-deriving -f-mtl
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-fthree
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-fthree -f-generic-deriving
-      compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-fthree -f-mtl
-      compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-fthree -f-generic-deriving -f-mtl
-      compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-ffour
-      compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-ffour -f-generic-deriving
-      compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-ffour -f-mtl
-      compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-ffour -f-generic-deriving -f-mtl
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.22 GHCVER=7.10.3
       compiler: ": #GHC 7.10.3"
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.10.3 -f-generic-deriving
-      compiler: ": #GHC 7.10.3"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.10.3 -f-mtl
-      compiler: ": #GHC 7.10.3"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.10.3 -f-generic-deriving -f-mtl
-      compiler: ": #GHC 7.10.3"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.22 GHCVER=7.10.3 -ffour
       compiler: ": #GHC 7.10.3"
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.10.3 -ffour -f-generic-deriving
-      compiler: ": #GHC 7.10.3"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.10.3 -ffour -f-mtl
-      compiler: ": #GHC 7.10.3"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.10.3 -ffour -f-generic-deriving -f-mtl
-      compiler: ": #GHC 7.10.3"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.1
-      compiler: ": #GHC 8.0.1"
-      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.24 GHCVER=8.0.1 OPTS=-f-generic-deriving
-      compiler: ": #GHC 8.0.1"
-      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.24 GHCVER=8.0.1 OPTS=-f-mtl
-      compiler: ": #GHC 8.0.1"
-      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.24 GHCVER=8.0.1 OPTS=-f-generic-deriving -f-mtl
       compiler: ": #GHC 8.0.1"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=head

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,22 +16,277 @@ matrix:
     - env: CABALVER=1.18 GHCVER=7.0.4
       compiler: ": #GHC 7.0.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS=-f-generic-deriving
+      compiler: ": #GHC 7.0.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS=-f-mtl
+      compiler: ": #GHC 7.0.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS=-f-mtl -f-generic-deriving
+      compiler: ": #GHC 7.0.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS=-ftwo
+      compiler: ": #GHC 7.0.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS=-ftwo -f-generic-deriving
+      compiler: ": #GHC 7.0.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS=-ftwo -f-mtl
+      compiler: ": #GHC 7.0.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS=-ftwo -f-generic-deriving -f-mtl
+      compiler: ": #GHC 7.0.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS=-fthree
+      compiler: ": #GHC 7.0.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS=-fthree -f-generic-deriving
+      compiler: ": #GHC 7.0.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS=-fthree -f-mtl
+      compiler: ": #GHC 7.0.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS=-fthree -f-generic-deriving -f-mtl
+      compiler: ": #GHC 7.0.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS=-ffour
+      compiler: ": #GHC 7.0.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS=-ffour -f-generic-deriving
+      compiler: ": #GHC 7.0.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS=-ffour -f-mtl
+      compiler: ": #GHC 7.0.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS=-ffour -f-generic-deriving -f-mtl
+      compiler: ": #GHC 7.0.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.2.2
+      compiler: ": #GHC 7.2.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-f-generic-deriving
+      compiler: ": #GHC 7.2.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-f-mtl
+      compiler: ": #GHC 7.2.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-f-mtl -f-generic-deriving
+      compiler: ": #GHC 7.2.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-ftwo
+      compiler: ": #GHC 7.2.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-ftwo -f-generic-deriving
+      compiler: ": #GHC 7.2.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-ftwo -f-mtl
+      compiler: ": #GHC 7.2.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-ftwo -f-generic-deriving -f-mtl
+      compiler: ": #GHC 7.2.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-fthree
+      compiler: ": #GHC 7.2.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-fthree -f-generic-deriving
+      compiler: ": #GHC 7.2.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-fthree -f-mtl
+      compiler: ": #GHC 7.2.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-fthree -f-generic-deriving -f-mtl
+      compiler: ": #GHC 7.2.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-ffour
+      compiler: ": #GHC 7.2.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-ffour -f-generic-deriving
+      compiler: ": #GHC 7.2.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-ffour -f-mtl
+      compiler: ": #GHC 7.2.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-ffour -f-generic-deriving -f-mtl
       compiler: ": #GHC 7.2.2"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.4.2
       compiler: ": #GHC 7.4.2"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-f-generic-deriving
+      compiler: ": #GHC 7.4.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-f-mtl
+      compiler: ": #GHC 7.4.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-f-mtl -f-generic-deriving
+      compiler: ": #GHC 7.4.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-ftwo
+      compiler: ": #GHC 7.4.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-ftwo -f-generic-deriving
+      compiler: ": #GHC 7.4.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-ftwo -f-mtl
+      compiler: ": #GHC 7.4.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-ftwo -f-generic-deriving -f-mtl
+      compiler: ": #GHC 7.4.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-fthree
+      compiler: ": #GHC 7.4.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-fthree -f-generic-deriving
+      compiler: ": #GHC 7.4.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-fthree -f-mtl
+      compiler: ": #GHC 7.4.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-fthree -f-generic-deriving -f-mtl
+      compiler: ": #GHC 7.4.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-ffour
+      compiler: ": #GHC 7.4.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-ffour -f-generic-deriving
+      compiler: ": #GHC 7.4.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-ffour -f-mtl
+      compiler: ": #GHC 7.4.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-ffour -f-generic-deriving -f-mtl
+      compiler: ": #GHC 7.4.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.6.3
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-f-generic-deriving
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-f-mtl
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-f-mtl -f-generic-deriving
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-ftwo
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-ftwo -f-generic-deriving
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-ftwo -f-mtl
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-ftwo -f-generic-deriving -f-mtl
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-fthree
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-fthree -f-generic-deriving
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-fthree -f-mtl
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-fthree -f-generic-deriving -f-mtl
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-ffour
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-ffour -f-generic-deriving
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-ffour -f-mtl
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-ffour -f-generic-deriving -f-mtl
       compiler: ": #GHC 7.6.3"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-f-generic-deriving
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-f-mtl
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-f-mtl -f-generic-deriving
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-ftwo
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-ftwo -f-generic-deriving
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-ftwo -f-mtl
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-ftwo -f-generic-deriving -f-mtl
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-fthree
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-fthree -f-generic-deriving
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-fthree -f-mtl
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-fthree -f-generic-deriving -f-mtl
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-ffour
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-ffour -f-generic-deriving
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-ffour -f-mtl
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-ffour -f-generic-deriving -f-mtl
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.22 GHCVER=7.10.3
       compiler: ": #GHC 7.10.3"
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3 -f-generic-deriving
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3 -f-mtl
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3 -f-generic-deriving -f-mtl
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3 -ffour
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3 -ffour -f-generic-deriving
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3 -ffour -f-mtl
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3 -ffour -f-generic-deriving -f-mtl
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.1
+      compiler: ": #GHC 8.0.1"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.1 OPTS=-f-generic-deriving
+      compiler: ": #GHC 8.0.1"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.1 OPTS=-f-mtl
+      compiler: ": #GHC 8.0.1"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.1 OPTS=-f-generic-deriving -f-mtl
       compiler: ": #GHC 8.0.1"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=head
@@ -55,7 +310,7 @@ install:
    fi
  - travis_retry cabal update -v
  - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
- - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt
+ - cabal install $OPTS --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt
  - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
 
 # check whether current requested install-plan matches cached package-db snapshot
@@ -69,7 +324,7 @@ install:
      echo "cabal build-cache MISS";
      rm -rf $HOME/.cabsnap;
      mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
-     cabal install -j --only-dependencies --enable-tests --enable-benchmarks;
+     cabal install $OPTS -j --only-dependencies --enable-tests --enable-benchmarks;
    fi
 
 # snapshot package-db on cache miss
@@ -84,21 +339,20 @@ install:
 # Here starts the actual work to be performed for the package under test;
 # any command which exits with a non-zero exit code causes the build to fail.
 script:
- - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
+ - cabal configure $OPTS --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
  - cabal build   # this builds all libraries and executables (including tests)
  - cabal test
  - hlint 0.2 --cpp-define HLINT
  - hlint 0.3 --cpp-define HLINT
  - hlint 0.5 --cpp-define HLINT
  - hlint src --cpp-define HLINT
- - cabal check
  - cabal sdist # tests that a source-distribution can be generated
 
 # Check that the resulting source distribution can be built & installed.
 # If there are no other `.tar.gz` files in `dist`, this can be even simpler:
 # `cabal install --force-reinstalls dist/*-*.tar.gz`
  - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
-   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
+   (cd dist && cabal install $OPTS --force-reinstalls "$SRC_TGZ")
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -170,7 +170,6 @@ install:
 script:
  - cabal configure $OPTS --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
  - cabal build   # this builds all libraries and executables (including tests)
- - cabal test
  - hlint 0.2 --cpp-define HLINT
  - hlint 0.3 --cpp-define HLINT
  - hlint 0.5 --cpp-define HLINT

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,104 @@
-language: haskell
+# This file has been generated -- see https://github.com/hvr/multi-ghc-travis
+language: c
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.cabsnap
+    - $HOME/.cabal/packages
+
+before_cache:
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/00-index.tar
+
+matrix:
+  include:
+    - env: CABALVER=1.18 GHCVER=7.0.4
+      compiler: ": #GHC 7.0.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.2.2
+      compiler: ": #GHC 7.2.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.4.2
+      compiler: ": #GHC 7.4.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.6.3
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.1
+      compiler: ": #GHC 8.0.1"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=head
+      compiler: ": #GHC head"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-head,hlint], sources: [hvr-ghc]}}
+
+  allow_failures:
+   - env: CABALVER=1.24 GHCVER=head
+
 before_install:
-  # Uncomment whenever hackage is down.
-  # - mkdir -p ~/.cabal && cp config ~/.cabal/config && cabal update
-
-  # Try installing some of the build-deps with apt-get for speed.
-  - ./travis-cabal-apt-install --only-dependencies --force-reinstall $mode
-
-  - sudo apt-get -q -y install hlint || cabal install hlint
+ - unset CC
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
 
 install:
-  - cabal configure $mode
-  - cabal build
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - if [ -f $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz ];
+   then
+     zcat $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz >
+          $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
+   fi
+ - travis_retry cabal update -v
+ - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt
+ - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
 
+# check whether current requested install-plan matches cached package-db snapshot
+ - if diff -u installplan.txt $HOME/.cabsnap/installplan.txt;
+   then
+     echo "cabal build-cache HIT";
+     rm -rfv .ghc;
+     cp -a $HOME/.cabsnap/ghc $HOME/.ghc;
+     cp -a $HOME/.cabsnap/lib $HOME/.cabsnap/share $HOME/.cabsnap/bin $HOME/.cabal/;
+   else
+     echo "cabal build-cache MISS";
+     rm -rf $HOME/.cabsnap;
+     mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
+     cabal install -j --only-dependencies --enable-tests --enable-benchmarks;
+   fi
+
+# snapshot package-db on cache miss
+ - if [ ! -d $HOME/.cabsnap ];
+   then
+      echo "snapshotting package-db to build-cache";
+      mkdir $HOME/.cabsnap;
+      cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
+      cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
+   fi
+
+# Here starts the actual work to be performed for the package under test;
+# any command which exits with a non-zero exit code causes the build to fail.
 script:
-  - $script
-  - hlint 0.2 --cpp-define HLINT
-  - hlint 0.3 --cpp-define HLINT
+ - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
+ - cabal build   # this builds all libraries and executables (including tests)
+ - cabal test
+ - hlint 0.2 --cpp-define HLINT
+ - hlint 0.3 --cpp-define HLINT
+ - hlint 0.5 --cpp-define HLINT
+ - hlint src --cpp-define HLINT
+ - cabal check
+ - cabal sdist # tests that a source-distribution can be generated
+
+# Check that the resulting source distribution can be built & installed.
+# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
+# `cabal install --force-reinstalls dist/*-*.tar.gz`
+ - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
+   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
 
 notifications:
   irc:
@@ -25,5 +108,4 @@ notifications:
     template:
       - "\x0313transformers-compat\x03/\x0306%{branch}\x03 \x0314%{commit}\x03 %{build_url} %{message}"
 
-env:
-  - mode="--enable-tests" script="cabal test"
+# EOF

--- a/0.3/Control/Monad/Trans/Except.hs
+++ b/0.3/Control/Monad/Trans/Except.hs
@@ -8,7 +8,7 @@
 #define MIN_VERSION_mtl(x,y,z) 1
 #endif
 
-#ifndef HASKELL98
+#ifdef MTL
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -70,7 +70,7 @@ import Control.Monad.Trans.Class
 import Control.Monad.Zip (MonadZip(mzipWith))
 #endif
 
-#ifndef HASKELL98
+#ifdef MTL
 import Control.Monad.Writer.Class
 import Control.Monad.State.Class
 import Control.Monad.Reader.Class
@@ -278,7 +278,7 @@ liftPass pass = mapExceptT $ \ m -> pass $ do
 
 -- incurring the mtl dependency for these avoids packages that need them introducing orphans.
 
-#ifndef HASKELL98
+#ifdef MTL
 
 instance Monad m => MonadError e (ExceptT e m) where
     throwError = throwE

--- a/0.3/Data/Functor/Sum.hs
+++ b/0.3/Data/Functor/Sum.hs
@@ -57,6 +57,7 @@ data Sum f g a = InL (f a) | InR (g a)
 
 #ifndef HASKELL98
 # if __GLASGOW_HASKELL__ >= 702 || defined(GENERIC_DERIVING)
+-- Generic(1) instances for Sum
 instance Generic (Sum f g a) where
     type Rep (Sum f g a) =
       D1 MDSum (C1 MCInL (S1 NoSelector (Rec0 (f a)))

--- a/0.5/Data/Functor/Classes/Generic.hs
+++ b/0.5/Data/Functor/Classes/Generic.hs
@@ -63,9 +63,8 @@ import GHC.Exts
 -- "Data.Functor.Classes.Generic" should behave.
 newtype Options = Options
   { ghc8ShowBehavior :: Bool
-    -- ^ If 'True', a default 'Show1' implementation will always omit
-    --   parentheses around a record constructor, regardless of precedence.
-    --   It will also show hash signs (@#@) when showing unlifted types.
+    -- ^ If 'True', a default 'Show1' implementation will show hash signs
+    -- (@#@) when showing unlifted types.
   }
 
 -- | Options that match the behavior of the installed version of GHC.
@@ -408,10 +407,7 @@ instance (GShow1 f, GShow1 g) => GShow1 (f :+: g) where
 instance (Constructor c, GShow1Con f, IsNullary f) => GShow1 (C1 c f) where
   gliftShowsPrec opts sp sl p c@(M1 x) = case fixity of
       Prefix -> showParen ( p > appPrec
-                             && not ( isNullary x
-                                      || conIsTuple c
-                                      || (conIsRecord c && ghc8ShowBehavior opts)
-                                    )
+                             && not (isNullary x || conIsTuple c)
                            ) $
              (if conIsTuple c
                  then id

--- a/0.5/Data/Functor/Classes/Generic.hs
+++ b/0.5/Data/Functor/Classes/Generic.hs
@@ -8,14 +8,22 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 module Data.Functor.Classes.Generic
-  ( -- * 'Eq1'
-    liftEqDefault
+  ( -- * Options
+    Options(..)
+  , defaultOptions
+  , latestGHCOptions
+    -- * 'Eq1'
+  , liftEqDefault
+  , liftEqOptions
     -- * 'Ord1'
   , liftCompareDefault
+  , liftCompareOptions
     -- * 'Read1'
   , liftReadsPrecDefault
+  , liftReadsPrecOptions
     -- * 'Show1'
   , liftShowsPrecDefault
+  , liftShowsPrecOptions
   ) where
 
 import Data.Functor.Classes
@@ -48,118 +56,161 @@ import GHC.Exts
 #endif
 
 ---------------------------------------------------------------------------------------
+-- * Options
+---------------------------------------------------------------------------------------
+
+-- | Options that further configure how the functions in
+-- "Data.Functor.Classes.Generic" should behave.
+newtype Options = Options
+  { ghc8ShowBehavior :: Bool
+    -- ^ If 'True', a default 'Show1' implementation will always omit
+    --   parentheses around a record constructor, regardless of precedence.
+    --   It will also show hash signs (@#@) when showing unlifted types.
+  }
+
+-- | Options that match the behavior of the installed version of GHC.
+defaultOptions :: Options
+defaultOptions = Options
+  {
+#if __GLASGOW_HASKELL__ >= 800
+  ghc8ShowBehavior = True
+#else
+  ghc8ShowBehavior = False
+#endif
+  }
+
+-- | Options that match the behavior of the most recent GHC release.
+latestGHCOptions :: Options
+latestGHCOptions = Options { ghc8ShowBehavior = True }
+
+---------------------------------------------------------------------------------------
 -- * Eq1
 ---------------------------------------------------------------------------------------
 
-liftEqDefault :: (GEq1 (Rep1 f), Generic1 f) => (a -> b -> Bool) -> f a -> f b -> Bool
-liftEqDefault f m n = gliftEq f (from1 m) (from1 n)
+-- | A sensible default 'liftEq' implementation for 'Generic1' instances.
+liftEqDefault :: (GEq1 (Rep1 f), Generic1 f)
+              => (a -> b -> Bool) -> f a -> f b -> Bool
+liftEqDefault = liftEqOptions defaultOptions
+
+-- | Like 'liftEqDefault', but with configurable 'Options'.
+liftEqOptions :: (GEq1 (Rep1 f), Generic1 f)
+              => Options -> (a -> b -> Bool) -> f a -> f b -> Bool
+liftEqOptions opts f m n = gliftEq opts f (from1 m) (from1 n)
 
 class GEq1 t where
-  gliftEq :: (a -> b -> Bool) -> t a -> t b -> Bool
+  gliftEq :: Options -> (a -> b -> Bool) -> t a -> t b -> Bool
 
 instance Eq c => GEq1 (K1 i c) where
-  gliftEq _ (K1 c) (K1 d) = c == d
+  gliftEq _ _ (K1 c) (K1 d) = c == d
 
 instance (GEq1 f, GEq1 g) => GEq1 (f :*: g) where
-  gliftEq f (a :*: b) (c :*: d) = gliftEq f a c && gliftEq f b d
+  gliftEq opts f (a :*: b) (c :*: d) = gliftEq opts f a c && gliftEq opts f b d
 
 instance (Eq1 f, GEq1 g) => GEq1 (f :.: g) where
-  gliftEq f (Comp1 m) (Comp1 n) = liftEq (gliftEq f) m n
+  gliftEq opts f (Comp1 m) (Comp1 n) = liftEq (gliftEq opts f) m n
 
 instance (GEq1 f, GEq1 g) => GEq1 (f :+: g) where
-  gliftEq f (L1 a) (L1 c) = gliftEq f a c
-  gliftEq f (R1 b) (R1 d) = gliftEq f b d
-  gliftEq _ _ _ = False
+  gliftEq opts f (L1 a) (L1 c) = gliftEq opts f a c
+  gliftEq opts f (R1 b) (R1 d) = gliftEq opts f b d
+  gliftEq _    _ _      _      = False
 
 instance GEq1 f => GEq1 (M1 i c f) where
-  gliftEq f (M1 a) (M1 b) = gliftEq f a b
+  gliftEq opts f (M1 a) (M1 b) = gliftEq opts f a b
 
 instance GEq1 U1 where
-  gliftEq _ U1 U1 = True
+  gliftEq _ _ U1 U1 = True
 
 instance GEq1 V1 where
-  gliftEq _ !_ = undefined
+  gliftEq _ _ !_ = undefined
 
 instance GEq1 Par1 where
-  gliftEq f (Par1 a) (Par1 b) = f a b
+  gliftEq _ f (Par1 a) (Par1 b) = f a b
 
 #if MIN_VERSION_base(4,9,0) || defined(GENERIC_DERIVING)
 -- Unboxed types
 instance GEq1 UAddr where
-  gliftEq _ (UAddr a1) (UAddr a2) = isTrue# (eqAddr# a1 a2)
+  gliftEq _ _ (UAddr a1) (UAddr a2) = isTrue# (eqAddr# a1 a2)
 
 instance GEq1 UChar where
-  gliftEq _ (UChar c1) (UChar c2) = isTrue# (eqChar# c1 c2)
+  gliftEq _ _ (UChar c1) (UChar c2) = isTrue# (eqChar# c1 c2)
 
 instance GEq1 UDouble where
-  gliftEq _ (UDouble d1) (UDouble d2) = isTrue# (d1 ==## d2)
+  gliftEq _ _ (UDouble d1) (UDouble d2) = isTrue# (d1 ==## d2)
 
 instance GEq1 UFloat where
-  gliftEq _ (UFloat f1) (UFloat f2) = isTrue# (eqFloat# f1 f2)
+  gliftEq _ _ (UFloat f1) (UFloat f2) = isTrue# (eqFloat# f1 f2)
 
 instance GEq1 UInt where
-  gliftEq _ (UInt i1) (UInt i2) = isTrue# (i1 ==# i2)
+  gliftEq _ _ (UInt i1) (UInt i2) = isTrue# (i1 ==# i2)
 
 instance GEq1 UWord where
-  gliftEq _ (UWord w1) (UWord w2) = isTrue# (eqWord# w1 w2)
+  gliftEq _ _ (UWord w1) (UWord w2) = isTrue# (eqWord# w1 w2)
 #endif
 
 ---------------------------------------------------------------------------------------
 -- * Ord1
 ---------------------------------------------------------------------------------------
 
-liftCompareDefault :: (GOrd1 (Rep1 f), Generic1 f) => (a -> b -> Ordering) -> f a -> f b -> Ordering
-liftCompareDefault f m n = gliftCompare f (from1 m) (from1 n)
+-- | A sensible default 'liftCompare' implementation for 'Generic1' instances.
+liftCompareDefault :: (GOrd1 (Rep1 f), Generic1 f)
+                   => (a -> b -> Ordering) -> f a -> f b -> Ordering
+liftCompareDefault = liftCompareOptions defaultOptions
+
+-- | Like 'liftCompareDefault', but with configurable 'Options'.
+liftCompareOptions :: (GOrd1 (Rep1 f), Generic1 f)
+                   => Options -> (a -> b -> Ordering) -> f a -> f b -> Ordering
+liftCompareOptions opts f m n = gliftCompare opts f (from1 m) (from1 n)
 
 class GOrd1 t where
-  gliftCompare :: (a -> b -> Ordering) -> t a -> t b -> Ordering
+  gliftCompare :: Options -> (a -> b -> Ordering) -> t a -> t b -> Ordering
 
 instance Ord c => GOrd1 (K1 i c) where
-  gliftCompare _ (K1 c) (K1 d) = compare c d
+  gliftCompare _ _ (K1 c) (K1 d) = compare c d
 
 instance (GOrd1 f, GOrd1 g) => GOrd1 (f :*: g) where
-  gliftCompare f (a :*: b) (c :*: d) = gliftCompare f a c `mappend` gliftCompare f b d
+  gliftCompare opts f (a :*: b) (c :*: d) =
+    gliftCompare opts f a c `mappend` gliftCompare opts f b d
 
 instance (Ord1 f, GOrd1 g) => GOrd1 (f :.: g) where
-  gliftCompare f (Comp1 m) (Comp1 n) = liftCompare (gliftCompare f) m n
+  gliftCompare opts f (Comp1 m) (Comp1 n) = liftCompare (gliftCompare opts f) m n
 
 instance (GOrd1 f, GOrd1 g) => GOrd1 (f :+: g) where
-  gliftCompare f (L1 a) (L1 c) = gliftCompare f a c
-  gliftCompare _ L1{} R1{} = LT
-  gliftCompare _ R1{} L1{} = GT
-  gliftCompare f (R1 b) (R1 d) = gliftCompare f b d
+  gliftCompare opts f (L1 a) (L1 c) = gliftCompare opts f a c
+  gliftCompare _    _ L1{}   R1{}   = LT
+  gliftCompare _    _ R1{}   L1{}   = GT
+  gliftCompare opts f (R1 b) (R1 d) = gliftCompare opts f b d
 
 instance GOrd1 f => GOrd1 (M1 i c f) where
-  gliftCompare f (M1 a) (M1 b) = gliftCompare f a b
+  gliftCompare opts f (M1 a) (M1 b) = gliftCompare opts f a b
 
 instance GOrd1 U1 where
-  gliftCompare _ U1 U1 = EQ
+  gliftCompare _ _ U1 U1 = EQ
 
 instance GOrd1 V1 where
-  gliftCompare _ !_ = undefined
+  gliftCompare _ _ !_ = undefined
 
 instance GOrd1 Par1 where
-  gliftCompare f (Par1 a) (Par1 b) = f a b
+  gliftCompare _ f (Par1 a) (Par1 b) = f a b
 
 #if MIN_VERSION_base(4,9,0) || defined(GENERIC_DERIVING)
 -- Unboxed types
 instance GOrd1 UAddr where
-  gliftCompare _ (UAddr a1) (UAddr a2) = primCompare (eqAddr# a1 a2) (leAddr# a1 a2)
+  gliftCompare _ _ (UAddr a1) (UAddr a2) = primCompare (eqAddr# a1 a2) (leAddr# a1 a2)
 
 instance GOrd1 UChar where
-  gliftCompare _ (UChar c1) (UChar c2) = primCompare (eqChar# c1 c2) (leChar# c1 c2)
+  gliftCompare _ _ (UChar c1) (UChar c2) = primCompare (eqChar# c1 c2) (leChar# c1 c2)
 
 instance GOrd1 UDouble where
-  gliftCompare _ (UDouble d1) (UDouble d2) = primCompare (d1 ==## d2) (d1 <=## d2)
+  gliftCompare _ _ (UDouble d1) (UDouble d2) = primCompare (d1 ==## d2) (d1 <=## d2)
 
 instance GOrd1 UFloat where
-  gliftCompare _ (UFloat f1) (UFloat f2) = primCompare (eqFloat# f1 f2) (leFloat# f1 f2)
+  gliftCompare _ _ (UFloat f1) (UFloat f2) = primCompare (eqFloat# f1 f2) (leFloat# f1 f2)
 
 instance GOrd1 UInt where
-  gliftCompare _ (UInt i1) (UInt i2) = primCompare (i1 ==# i2) (i1 <=# i2)
+  gliftCompare _ _ (UInt i1) (UInt i2) = primCompare (i1 ==# i2) (i1 <=# i2)
 
 instance GOrd1 UWord where
-  gliftCompare _ (UWord w1) (UWord w2) = primCompare (eqWord# w1 w2) (leWord# w1 w2)
+  gliftCompare _ _ (UWord w1) (UWord w2) = primCompare (eqWord# w1 w2) (leWord# w1 w2)
 
 # if __GLASGOW_HASKELL__ >= 708
 primCompare :: Int# -> Int# -> Ordering
@@ -175,10 +226,17 @@ primCompare eq le = if isTrue# eq then EQ
 -- * Read1
 ---------------------------------------------------------------------------------------
 
+-- | A sensible default 'liftReadsPrec' implementation for 'Generic1' instances.
 liftReadsPrecDefault :: (GRead1 (Rep1 f), Generic1 f)
                      => (Int -> ReadS a) -> ReadS [a] -> Int -> ReadS (f a)
-liftReadsPrecDefault rp rl p =
-  readPrec_to_S (fmap to1 $ parens $ gliftReadPrec (readS_to_Prec rp)
+liftReadsPrecDefault = liftReadsPrecOptions defaultOptions
+
+-- | Like 'liftReadsPrecDefault', but with configurable 'Options'.
+liftReadsPrecOptions :: (GRead1 (Rep1 f), Generic1 f)
+                     => Options -> (Int -> ReadS a) -> ReadS [a] -> Int -> ReadS (f a)
+liftReadsPrecOptions opts rp rl p =
+  readPrec_to_S (fmap to1 $ parens $ gliftReadPrec opts
+                                                   (readS_to_Prec rp)
                                                    (readS_to_Prec (const rl))) p
 
 #if !(MIN_VERSION_base(4,7,0))
@@ -195,19 +253,20 @@ coerceM1 :: ReadPrec (f p) -> ReadPrec (M1 i c f p)
 coerceM1 = coerce
 
 class GRead1 f where
-  gliftReadPrec :: ReadPrec a -> ReadPrec [a] -> ReadPrec (f a)
+  gliftReadPrec :: Options -> ReadPrec a -> ReadPrec [a] -> ReadPrec (f a)
 
 instance GRead1 f => GRead1 (D1 d f) where
-  gliftReadPrec rp = coerceM1 . gliftReadPrec rp
+  gliftReadPrec opts rp = coerceM1 . gliftReadPrec opts rp
 
 instance GRead1 V1 where
-  gliftReadPrec _ _ = pfail
+  gliftReadPrec _ _ _ = pfail
 
 instance (GRead1 f, GRead1 g) => GRead1 (f :+: g) where
-  gliftReadPrec rp rl = fmap L1 (gliftReadPrec rp rl) +++ fmap R1 (gliftReadPrec rp rl)
+  gliftReadPrec opts rp rl =
+    fmap L1 (gliftReadPrec opts rp rl) +++ fmap R1 (gliftReadPrec opts rp rl)
 
 instance (Constructor c, GRead1Con f, IsNullary f) => GRead1 (C1 c f) where
-  gliftReadPrec rp rl = coerceM1 $ case fixity of
+  gliftReadPrec opts rp rl = coerceM1 $ case fixity of
       Prefix -> precIfNonNullary $ do
                   if conIsTuple c
                      then return ()
@@ -215,8 +274,8 @@ instance (Constructor c, GRead1Con f, IsNullary f) => GRead1 (C1 c f) where
                           in if isInfixTypeCon cn
                                 then readSurround '(' (expectP (Symbol cn)) ')'
                                 else expectP (Ident cn)
-                  readBraces t (gliftReadPrecCon t rp rl)
-      Infix _ m -> prec m $ gliftReadPrecCon t rp rl
+                  readBraces t (gliftReadPrecCon opts t rp rl)
+      Infix _ m -> prec m $ gliftReadPrecCon opts t rp rl
     where
       c :: C1 c f p
       c = undefined
@@ -257,50 +316,50 @@ readSurround c1 r c2 = do
   return r'
 
 class GRead1Con f where
-  gliftReadPrecCon :: ConType -> ReadPrec a -> ReadPrec [a] -> ReadPrec (f a)
+  gliftReadPrecCon :: Options -> ConType -> ReadPrec a -> ReadPrec [a] -> ReadPrec (f a)
 
 instance GRead1Con U1 where
-  gliftReadPrecCon _ _ _ = return U1
+  gliftReadPrecCon _ _ _ _ = return U1
 
 instance GRead1Con Par1 where
-  gliftReadPrecCon _ rp _ = coercePar1 rp
+  gliftReadPrecCon _ _ rp _ = coercePar1 rp
     where
       coercePar1 :: ReadPrec p -> ReadPrec (Par1 p)
       coercePar1 = coerce
 
 instance Read c => GRead1Con (K1 i c) where
-  gliftReadPrecCon _ _ _ = coerceK1 readPrec
+  gliftReadPrecCon _ _ _ _ = coerceK1 readPrec
     where
       coerceK1 :: ReadPrec c -> ReadPrec (K1 i c p)
       coerceK1 = coerce
 
 instance Read1 f => GRead1Con (Rec1 f) where
-  gliftReadPrecCon _ rp rl = coerceRec1 $ readS_to_Prec $
+  gliftReadPrecCon _ _ rp rl = coerceRec1 $ readS_to_Prec $
       liftReadsPrec (readPrec_to_S rp) (readPrec_to_S rl 0)
     where
       coerceRec1 :: ReadPrec (f a) -> ReadPrec (Rec1 f a)
       coerceRec1 = coerce
 
 instance (Selector s, GRead1Con f) => GRead1Con (S1 s f) where
-  gliftReadPrecCon t rp rl
-    | selectorName == "" = coerceM1 $ step $ gliftReadPrecCon t rp rl
+  gliftReadPrecCon opts t rp rl
+    | selectorName == "" = coerceM1 $ step $ gliftReadPrecCon opts t rp rl
     | otherwise          = coerceM1 $ do
                               expectP (Ident selectorName)
                               expectP (Punc "=")
-                              reset $ gliftReadPrecCon t rp rl
+                              reset $ gliftReadPrecCon opts t rp rl
     where
       selectorName :: String
       selectorName = selName (undefined :: S1 s f p)
 
 instance (GRead1Con f, GRead1Con g) => GRead1Con (f :*: g) where
-  gliftReadPrecCon t rp rl = do
-      l <- gliftReadPrecCon t rp rl
+  gliftReadPrecCon opts t rp rl = do
+      l <- gliftReadPrecCon opts t rp rl
       case t of
            Rec   -> expectP (Punc "=")
            Inf o -> infixPrec o
            Tup   -> expectP (Punc ",")
            Pref  -> return ()
-      r <- gliftReadPrecCon t rp rl
+      r <- gliftReadPrecCon opts t rp rl
       return (l :*: r)
     where
       infixPrec :: String -> ReadPrec ()
@@ -309,9 +368,9 @@ instance (GRead1Con f, GRead1Con g) => GRead1Con (f :*: g) where
                        else mapM_ expectP [Punc "`", Ident o, Punc "`"]
 
 instance (Read1 f, GRead1Con g) => GRead1Con (f :.: g) where
-  gliftReadPrecCon t rp rl = coerceComp1 $ readS_to_Prec $
-      liftReadsPrec (readPrec_to_S       (gliftReadPrecCon t rp rl))
-                    (readPrec_to_S (list (gliftReadPrecCon t rp rl)) 0)
+  gliftReadPrecCon opts t rp rl = coerceComp1 $ readS_to_Prec $
+      liftReadsPrec (readPrec_to_S       (gliftReadPrecCon opts t rp rl))
+                    (readPrec_to_S (list (gliftReadPrecCon opts t rp rl)) 0)
     where
       coerceComp1 :: ReadPrec (f (g a)) -> ReadPrec ((f :.: g) a)
       coerceComp1 = coerce
@@ -320,31 +379,38 @@ instance (Read1 f, GRead1Con g) => GRead1Con (f :.: g) where
 -- * Show1
 ---------------------------------------------------------------------------------------
 
+-- | A sensible default 'liftShowsPrec' implementation for 'Generic1' instances.
 liftShowsPrecDefault :: (GShow1 (Rep1 f), Generic1 f)
-                     => (Int -> a -> ShowS) -> ([a] -> ShowS) -> Int -> f a -> ShowS
-liftShowsPrecDefault sp sl p = gliftShowsPrec sp sl p . from1
+                     => (Int -> a -> ShowS) -> ([a] -> ShowS)
+                     -> Int -> f a -> ShowS
+liftShowsPrecDefault = liftShowsPrecOptions defaultOptions
+
+-- | Like 'liftShowsPrecDefault', but with configurable 'Options'.
+liftShowsPrecOptions :: (GShow1 (Rep1 f), Generic1 f)
+                     => Options -> (Int -> a -> ShowS) -> ([a] -> ShowS)
+                     -> Int -> f a -> ShowS
+liftShowsPrecOptions opts sp sl p = gliftShowsPrec opts sp sl p . from1
 
 class GShow1 f where
-  gliftShowsPrec :: (Int -> a -> ShowS) -> ([a] -> ShowS) -> Int -> f a -> ShowS
+  gliftShowsPrec :: Options -> (Int -> a -> ShowS) -> ([a] -> ShowS)
+                 -> Int -> f a -> ShowS
 
 instance GShow1 f => GShow1 (D1 d f) where
-  gliftShowsPrec sp sl p (M1 x) = gliftShowsPrec sp sl p x
+  gliftShowsPrec opts sp sl p (M1 x) = gliftShowsPrec opts sp sl p x
 
 instance GShow1 V1 where
-  gliftShowsPrec _ _ _ !_ = undefined
+  gliftShowsPrec _ _ _ _ !_ = undefined
 
 instance (GShow1 f, GShow1 g) => GShow1 (f :+: g) where
-  gliftShowsPrec sp sl p (L1 x) = gliftShowsPrec sp sl p x
-  gliftShowsPrec sp sl p (R1 x) = gliftShowsPrec sp sl p x
+  gliftShowsPrec opts sp sl p (L1 x) = gliftShowsPrec opts sp sl p x
+  gliftShowsPrec opts sp sl p (R1 x) = gliftShowsPrec opts sp sl p x
 
 instance (Constructor c, GShow1Con f, IsNullary f) => GShow1 (C1 c f) where
-  gliftShowsPrec sp sl p c@(M1 x) = case fixity of
+  gliftShowsPrec opts sp sl p c@(M1 x) = case fixity of
       Prefix -> showParen ( p > appPrec
                              && not ( isNullary x
                                       || conIsTuple c
-#if __GLASGOW_HASKELL__ >= 711
-                                      || conIsRecord c
-#endif
+                                      || (conIsRecord c && ghc8ShowBehavior opts)
                                     )
                            ) $
              (if conIsTuple c
@@ -354,8 +420,8 @@ instance (Constructor c, GShow1Con f, IsNullary f) => GShow1 (C1 c f) where
            . (if isNullary x || conIsTuple c
                  then id
                  else showChar ' ')
-           . showBraces t (gliftShowsPrecCon t sp sl appPrec1 x)
-      Infix _ m -> showParen (p > m) $ gliftShowsPrecCon t sp sl (m+1) x
+           . showBraces t (gliftShowsPrecCon opts t sp sl appPrec1 x)
+      Infix _ m -> showParen (p > m) $ gliftShowsPrecCon opts t sp sl (m+1) x
     where
       fixity :: Fixity
       fixity = conFixity c
@@ -376,48 +442,49 @@ showBraces Pref    b = b
 showBraces (Inf _) b = b
 
 class GShow1Con f where
-  gliftShowsPrecCon :: ConType -> (Int -> a -> ShowS) -> ([a] -> ShowS)
+  gliftShowsPrecCon :: Options -> ConType
+                    -> (Int -> a -> ShowS) -> ([a] -> ShowS)
                     -> Int -> f a -> ShowS
 
 instance GShow1Con U1 where
-  gliftShowsPrecCon _ _ _ _ U1 = id
+  gliftShowsPrecCon _ _ _ _ _ U1 = id
 
 instance GShow1Con Par1 where
-  gliftShowsPrecCon _ sp _  p (Par1 x) = sp p x
+  gliftShowsPrecCon _ _ sp _  p (Par1 x) = sp p x
 
 instance Show c => GShow1Con (K1 i c) where
-  gliftShowsPrecCon _ _ _ p (K1 x) = showsPrec p x
+  gliftShowsPrecCon _ _ _ _ p (K1 x) = showsPrec p x
 
 instance Show1 f => GShow1Con (Rec1 f) where
-  gliftShowsPrecCon _ sp sl p (Rec1 x) = liftShowsPrec sp sl p x
+  gliftShowsPrecCon _ _ sp sl p (Rec1 x) = liftShowsPrec sp sl p x
 
 instance (Selector s, GShow1Con f) => GShow1Con (S1 s f) where
-  gliftShowsPrecCon t sp sl p sel@(M1 x)
-    | selName sel == "" =   gliftShowsPrecCon t sp sl p x
+  gliftShowsPrecCon opts t sp sl p sel@(M1 x)
+    | selName sel == "" =   gliftShowsPrecCon opts t sp sl p x
     | otherwise         =   showString (selName sel)
                           . showString " = "
-                          . gliftShowsPrecCon t sp sl 0 x
+                          . gliftShowsPrecCon opts t sp sl 0 x
 
 instance (GShow1Con f, GShow1Con g) => GShow1Con (f :*: g) where
-  gliftShowsPrecCon t sp sl p (a :*: b) =
+  gliftShowsPrecCon opts t sp sl p (a :*: b) =
     case t of
-         Rec ->     gliftShowsPrecCon t sp sl 0 a
+         Rec ->     gliftShowsPrecCon opts t sp sl 0 a
                   . showString ", "
-                  . gliftShowsPrecCon t sp sl 0 b
+                  . gliftShowsPrecCon opts t sp sl 0 b
 
-         Inf o ->   gliftShowsPrecCon t sp sl p a
+         Inf o ->   gliftShowsPrecCon opts t sp sl p a
                   . showSpace
                   . infixOp o
                   . showSpace
-                  . gliftShowsPrecCon t sp sl p b
+                  . gliftShowsPrecCon opts t sp sl p b
 
-         Tup ->     gliftShowsPrecCon t sp sl 0 a
+         Tup ->     gliftShowsPrecCon opts t sp sl 0 a
                   . showChar ','
-                  . gliftShowsPrecCon t sp sl 0 b
+                  . gliftShowsPrecCon opts t sp sl 0 b
 
-         Pref ->    gliftShowsPrecCon t sp sl p a
+         Pref ->    gliftShowsPrecCon opts t sp sl p a
                   . showSpace
-                  . gliftShowsPrecCon t sp sl p b
+                  . gliftShowsPrecCon opts t sp sl p b
     where
       infixOp :: String -> ShowS
       infixOp o = if isInfixTypeCon o
@@ -425,38 +492,37 @@ instance (GShow1Con f, GShow1Con g) => GShow1Con (f :*: g) where
                      else showChar '`' . showString o . showChar '`'
 
 instance (Show1 f, GShow1Con g) => GShow1Con (f :.: g) where
-  gliftShowsPrecCon t sp sl p (Comp1 x) =
-    liftShowsPrec (gliftShowsPrecCon t sp sl)
-                  (showListWith (gliftShowsPrecCon t sp sl 0))
+  gliftShowsPrecCon opts t sp sl p (Comp1 x) =
+    liftShowsPrec (gliftShowsPrecCon opts t sp sl)
+                  (showListWith (gliftShowsPrecCon opts t sp sl 0))
                   p x
 
 #if MIN_VERSION_base(4,9,0) || defined(GENERIC_DERIVING)
 instance GShow1Con UChar where
-  gliftShowsPrecCon _ _ _ p (UChar c)   = showsPrec (hashPrec p) (C# c) . oneHash
+  gliftShowsPrecCon opts _ _ _ p (UChar c) =
+    showsPrec (hashPrec opts p) (C# c) . oneHash opts
 
 instance GShow1Con UDouble where
-  gliftShowsPrecCon _ _ _ p (UDouble d) = showsPrec (hashPrec p) (D# d) . twoHash
+  gliftShowsPrecCon opts _ _ _ p (UDouble d) =
+    showsPrec (hashPrec opts p) (D# d) . twoHash opts
 
 instance GShow1Con UFloat where
-  gliftShowsPrecCon _ _ _ p (UFloat f)  = showsPrec (hashPrec p) (F# f) . oneHash
+  gliftShowsPrecCon opts _ _ _ p (UFloat f) =
+    showsPrec (hashPrec opts p) (F# f) . oneHash opts
 
 instance GShow1Con UInt where
-  gliftShowsPrecCon _ _ _ p (UInt i)    = showsPrec (hashPrec p) (I# i) . oneHash
+  gliftShowsPrecCon opts _ _ _ p (UInt i) =
+    showsPrec (hashPrec opts p) (I# i) . oneHash opts
 
 instance GShow1Con UWord where
-  gliftShowsPrecCon _ _ _ p (UWord w)   = showsPrec (hashPrec p) (W# w) . twoHash
+  gliftShowsPrecCon opts _ _ _ p (UWord w) =
+    showsPrec (hashPrec opts p) (W# w) . twoHash opts
 
-oneHash, twoHash :: ShowS
-hashPrec :: Int -> Int
-# if __GLASGOW_HASKELL__ >= 711
-oneHash  = showChar '#'
-twoHash  = showString "##"
-hashPrec = const 0
-# else
-oneHash  = id
-twoHash  = id
-hashPrec = id
-# endif
+oneHash, twoHash :: Options -> ShowS
+hashPrec         :: Options -> Int -> Int
+oneHash  opts = if ghc8ShowBehavior opts then showChar   '#'  else id
+twoHash  opts = if ghc8ShowBehavior opts then showString "##" else id
+hashPrec opts = if ghc8ShowBehavior opts then const 0         else id
 #endif
 
 ---------------------------------------------------------------------------------------

--- a/src/Control/Monad/Trans/Instances.hs
+++ b/src/Control/Monad/Trans/Instances.hs
@@ -10,7 +10,6 @@
 {-# LANGUAGE TypeOperators #-}
 
 # if __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE Trustworthy #-}
 # endif
 
@@ -93,7 +92,9 @@ import           Data.Bifunctor (Bifunctor(..))
 import           Data.Data (Data)
 import           Data.Typeable
 
-# if __GLASGOW_HASKELL__ >= 702
+# ifdef GENERIC_DERIVING
+import           Generics.Deriving.Base
+# elif __GLASGOW_HASKELL__ >= 702
 import           GHC.Generics
 # endif
 #endif
@@ -276,7 +277,7 @@ deriving instance Typeable Product
 deriving instance Typeable1 Identity
 deriving instance Data a => Data (Identity a)
 
-#   if __GLASGOW_HASKELL__ >= 702
+#   if __GLASGOW_HASKELL__ >= 702 || defined(GENERIC_DERIVING)
 instance Generic (Identity a) where
     type Rep (Identity a) = D1 MDIdentity (C1 MCIdentity (S1 MSIdentity (Rec0 a)))
     from (Identity x) = M1 (M1 (M1 (K1 x)))
@@ -312,7 +313,7 @@ deriving instance Typeable 'Identity
 #  endif
 
 #  if !(MIN_VERSION_base(4,9,0))
-#   if __GLASGOW_HASKELL__ >= 702
+#   if __GLASGOW_HASKELL__ >= 702 || defined(GENERIC_DERIVING)
 -- Generic(1) instances for Compose
 instance Generic (Compose f g a) where
     type Rep (Compose f g a) =

--- a/src/Control/Monad/Trans/Instances.hs
+++ b/src/Control/Monad/Trans/Instances.hs
@@ -68,7 +68,7 @@ import           Data.Functor.Constant (Constant(..))
 import           Data.Functor.Identity (Identity(..))
 import           Data.Functor.Product (Product(..))
 import           Data.Functor.Reverse (Reverse(..))
-import           Data.Functor.Sum ()
+import           Data.Functor.Sum (Sum(..))
 
 import           Control.Applicative
 import           Control.Monad (MonadPlus(..))
@@ -276,113 +276,27 @@ deriving instance Typeable Product
 #  if !(MIN_VERSION_base(4,8,0))
 deriving instance Typeable1 Identity
 deriving instance Data a => Data (Identity a)
-
-#   if __GLASGOW_HASKELL__ >= 702 || defined(GENERIC_DERIVING)
-instance Generic (Identity a) where
-    type Rep (Identity a) = D1 MDIdentity (C1 MCIdentity (S1 MSIdentity (Rec0 a)))
-    from (Identity x) = M1 (M1 (M1 (K1 x)))
-    to (M1 (M1 (M1 (K1 x)))) = Identity x
-
-instance Generic1 Identity where
-    type Rep1 Identity = D1 MDIdentity (C1 MCIdentity (S1 MSIdentity Par1))
-    from1 (Identity x) = M1 (M1 (M1 (Par1 x)))
-    to1 (M1 (M1 (M1 x))) = Identity (unPar1 x)
-
-data MDIdentity
-data MCIdentity
-data MSIdentity
-
-instance Datatype MDIdentity where
-  datatypeName _ = "Identity"
-  moduleName _ = "Data.Functor.Identity"
-#    if __GLASGOW_HASKELL__ >= 708
-  isNewtype _ = True
-#    endif
-
-instance Constructor MCIdentity where
-  conName _ = "Identity"
-  conIsRecord _ = True
-
-instance Selector MSIdentity where
-  selName _ = "runIdentity"
-#   endif
-
 #   if __GLASGOW_HASKELL__ >= 708
 deriving instance Typeable 'Identity
 #   endif
 #  endif
 
 #  if !(MIN_VERSION_base(4,9,0))
-#   if __GLASGOW_HASKELL__ >= 702 || defined(GENERIC_DERIVING)
--- Generic(1) instances for Compose
-instance Generic (Compose f g a) where
-    type Rep (Compose f g a) =
-      D1 MDCompose
-        (C1 MCCompose
-          (S1 MSCompose (Rec0 (f (g a)))))
-    from (Compose x) = M1 (M1 (M1 (K1 x)))
-    to (M1 (M1 (M1 (K1 x)))) = Compose x
-
-instance Functor f => Generic1 (Compose f g) where
-    type Rep1 (Compose f g) =
-      D1 MDCompose
-        (C1 MCCompose
-          (S1 MSCompose (f :.: Rec1 g)))
-    from1 (Compose x) = M1 (M1 (M1 (Comp1 (fmap Rec1 x))))
-    to1 (M1 (M1 (M1 x))) = Compose (fmap unRec1 (unComp1 x))
-
-data MDCompose
-data MCCompose
-data MSCompose
-
-instance Datatype MDCompose where
-    datatypeName _ = "Compose"
-    moduleName   _ = "Data.Functor.Compose"
-#    if __GLASGOW_HASKELL__ >= 708
-    isNewtype    _ = True
-#    endif
-
-instance Constructor MCCompose where
-    conName     _ = "Compose"
-    conIsRecord _ = True
-
-instance Selector MSCompose where
-    selName _ = "getCompose"
-
--- Generic(1) instances for Product
-instance Generic (Product f g a) where
-    type Rep (Product f g a) =
-      D1 MDProduct
-        (C1 MCPair
-          (S1 NoSelector (Rec0 (f a)) :*: S1 NoSelector (Rec0 (g a))))
-    from (Pair f g) = M1 (M1 (M1 (K1 f) :*: M1 (K1 g)))
-    to (M1 (M1 (M1 (K1 f) :*: M1 (K1 g)))) = Pair f g
-
-instance Generic1 (Product f g) where
-    type Rep1 (Product f g) =
-      D1 MDProduct
-        (C1 MCPair
-          (S1 NoSelector (Rec1 f) :*: S1 NoSelector (Rec1 g)))
-    from1 (Pair f g) = M1 (M1 (M1 (Rec1 f) :*: M1 (Rec1 g)))
-    to1 (M1 (M1 (M1 f :*: M1 g))) = Pair (unRec1 f) (unRec1 g)
-
-data MDProduct
-data MCPair
-
-instance Datatype MDProduct where
-    datatypeName _ = "Product"
-    moduleName   _ = "Data.Functor.Product"
-
-instance Constructor MCPair where
-    conName _ = "Pair"
-#   endif
-
 #   if __GLASGOW_HASKELL__ >= 708
 -- Data instances for Compose and Product
 deriving instance (Data (f (g a)), Typeable f, Typeable g, Typeable a)
                => Data (Compose (f :: * -> *) (g :: * -> *) (a :: *))
 deriving instance (Data (f a), Data (g a), Typeable f, Typeable g, Typeable a)
                => Data (Product (f :: * -> *) (g :: * -> *) (a :: *))
+
+#    if MIN_VERSION_transformers(0,4,0)
+-- Typeable/Data instances for Sum
+-- These are also present in Data.Functor.Sum in transformers-compat, but only
+-- these are reachable if using @transformers-0.4.0.0@
+deriving instance Typeable Sum
+deriving instance (Data (f a), Data (g a), Typeable f, Typeable g, Typeable a)
+               => Data (Sum (f :: * -> *) (g :: * -> *) (a :: *))
+#    endif
 #   endif
 #  endif
 # endif
@@ -420,5 +334,144 @@ instance (Storable a) => Storable (Identity a) where
     pokeByteOff p i (Identity x) = pokeByteOff p i x
     peek p                       = fmap runIdentity (peek (castPtr p))
     poke p (Identity x)          = poke (castPtr p) x
+# endif
+#endif
+
+-- Generic(1) instances
+#ifndef HASKELL98
+# if (!(MIN_VERSION_transformers(0,5,0)) && (__GLASGOW_HASKELL__ >= 702 || defined(GENERIC_DERIVING))) \
+    || (MIN_VERSION_transformers(0,5,0)  &&  __GLASGOW_HASKELL__ < 702  && defined(GENERIC_DERIVING))
+
+#  if !(MIN_VERSION_base(4,8,0))
+instance Generic (Identity a) where
+    type Rep (Identity a) = D1 MDIdentity (C1 MCIdentity (S1 MSIdentity (Rec0 a)))
+    from (Identity x) = M1 (M1 (M1 (K1 x)))
+    to (M1 (M1 (M1 (K1 x)))) = Identity x
+
+instance Generic1 Identity where
+    type Rep1 Identity = D1 MDIdentity (C1 MCIdentity (S1 MSIdentity Par1))
+    from1 (Identity x) = M1 (M1 (M1 (Par1 x)))
+    to1 (M1 (M1 (M1 x))) = Identity (unPar1 x)
+
+data MDIdentity
+data MCIdentity
+data MSIdentity
+
+instance Datatype MDIdentity where
+  datatypeName _ = "Identity"
+  moduleName _ = "Data.Functor.Identity"
+#   if __GLASGOW_HASKELL__ >= 708
+  isNewtype _ = True
+#   endif
+
+instance Constructor MCIdentity where
+  conName _ = "Identity"
+  conIsRecord _ = True
+
+instance Selector MSIdentity where
+  selName _ = "runIdentity"
+#  endif
+
+#  if !(MIN_VERSION_base(4,9,0))
+-- Generic(1) instances for Compose
+instance Generic (Compose f g a) where
+    type Rep (Compose f g a) =
+      D1 MDCompose
+        (C1 MCCompose
+          (S1 MSCompose (Rec0 (f (g a)))))
+    from (Compose x) = M1 (M1 (M1 (K1 x)))
+    to (M1 (M1 (M1 (K1 x)))) = Compose x
+
+instance Functor f => Generic1 (Compose f g) where
+    type Rep1 (Compose f g) =
+      D1 MDCompose
+        (C1 MCCompose
+          (S1 MSCompose (f :.: Rec1 g)))
+    from1 (Compose x) = M1 (M1 (M1 (Comp1 (fmap Rec1 x))))
+    to1 (M1 (M1 (M1 x))) = Compose (fmap unRec1 (unComp1 x))
+
+data MDCompose
+data MCCompose
+data MSCompose
+
+instance Datatype MDCompose where
+    datatypeName _ = "Compose"
+    moduleName   _ = "Data.Functor.Compose"
+#   if __GLASGOW_HASKELL__ >= 708
+    isNewtype    _ = True
+#   endif
+
+instance Constructor MCCompose where
+    conName     _ = "Compose"
+    conIsRecord _ = True
+
+instance Selector MSCompose where
+    selName _ = "getCompose"
+
+-- Generic(1) instances for Product
+instance Generic (Product f g a) where
+    type Rep (Product f g a) =
+      D1 MDProduct
+        (C1 MCPair
+          (S1 NoSelector (Rec0 (f a)) :*: S1 NoSelector (Rec0 (g a))))
+    from (Pair f g) = M1 (M1 (M1 (K1 f) :*: M1 (K1 g)))
+    to (M1 (M1 (M1 (K1 f) :*: M1 (K1 g)))) = Pair f g
+
+instance Generic1 (Product f g) where
+    type Rep1 (Product f g) =
+      D1 MDProduct
+        (C1 MCPair
+          (S1 NoSelector (Rec1 f) :*: S1 NoSelector (Rec1 g)))
+    from1 (Pair f g) = M1 (M1 (M1 (Rec1 f) :*: M1 (Rec1 g)))
+    to1 (M1 (M1 (M1 f :*: M1 g))) = Pair (unRec1 f) (unRec1 g)
+
+data MDProduct
+data MCPair
+
+instance Datatype MDProduct where
+    datatypeName _ = "Product"
+    moduleName   _ = "Data.Functor.Product"
+
+instance Constructor MCPair where
+    conName _ = "Pair"
+
+#   if MIN_VERSION_transformers(0,4,0)
+-- Generic(1) instances for Sum
+-- These are also present in Data.Functor.Sum in transformers-compat, but only
+-- these are reachable if using @transformers-0.4.0.0@ or later
+instance Generic (Sum f g a) where
+    type Rep (Sum f g a) =
+      D1 MDSum (C1 MCInL (S1 NoSelector (Rec0 (f a)))
+            :+: C1 MCInR (S1 NoSelector (Rec0 (g a))))
+    from (InL f) = M1 (L1 (M1 (M1 (K1 f))))
+    from (InR g) = M1 (R1 (M1 (M1 (K1 g))))
+    to (M1 (L1 (M1 (M1 (K1 f))))) = InL f
+    to (M1 (R1 (M1 (M1 (K1 g))))) = InR g
+
+instance Generic1 (Sum f g) where
+    type Rep1 (Sum f g) =
+      D1 MDSum (C1 MCInL (S1 NoSelector (Rec1 f))
+            :+: C1 MCInR (S1 NoSelector (Rec1 g)))
+    from1 (InL f) = M1 (L1 (M1 (M1 (Rec1 f))))
+    from1 (InR g) = M1 (R1 (M1 (M1 (Rec1 g))))
+    to1 (M1 (L1 (M1 (M1 f)))) = InL (unRec1 f)
+    to1 (M1 (R1 (M1 (M1 g)))) = InR (unRec1 g)
+
+data MDSum
+data MCInL
+data MCInR
+
+instance Datatype MDSum where
+    datatypeName _ = "Sum"
+    moduleName   _ = "Data.Functor.Sum"
+
+instance Constructor MCInL where
+    conName _ = "InL"
+
+instance Constructor MCInR where
+    conName _ = "InR"
+#   endif
+#  endif
+
 # endif
 #endif

--- a/transformers-compat.cabal
+++ b/transformers-compat.cabal
@@ -58,6 +58,15 @@ flag mtl
   manual: True
   description: -f-mtl Disables support for mtl for transformers 0.2 and 0.3. That is an unsupported configuration, and results in missing instances for `ExceptT`.
 
+flag generic-deriving
+  default: True
+  manual: True
+  description: -f-generic-deriving prevents generic-deriving from being built as a dependency.
+               This disables certain aspects of generics for older versions of GHC. In particular,
+               Generic(1) instances will not be backported prior to GHC 7.2, and generic operations
+               over unlifted types will not be backported prior to GHC 8.0. This is an unsupported
+               configuration.
+
 library
   build-depends:
     base >= 4.3 && < 5
@@ -93,6 +102,9 @@ library
     cpp-options: -DHASKELL98
   else
     build-depends: ghc-prim
+    if impl(ghc < 8.0) && flag(generic-deriving)
+      cpp-options: -DGENERIC_DERIVING
+      build-depends: generic-deriving >= 1.10 && < 2
 
   if flag(two)
     exposed-modules:
@@ -107,6 +119,6 @@ library
       Data.Functor.Classes
       Data.Functor.Sum
 
-  if !flag(four) && impl(ghc >= 7.2)
+  if !flag(four) && (impl(ghc >= 7.2) || flag(generic-deriving))
     exposed-modules:
       Data.Functor.Classes.Generic

--- a/transformers-compat.cabal
+++ b/transformers-compat.cabal
@@ -23,7 +23,13 @@ description:
   Note: missing methods are not supplied, but this at least permits the types to be used.
 
 build-type:    Simple
-tested-with:   GHC == 7.0.4, GHC == 7.4.1, GHC == 7.4.2, GHC == 7.6.1, GHC == 7.8.2, GHC == 7.10.3, GHC == 8.0.1
+tested-with:   GHC == 7.0.4
+             , GHC == 7.2.2
+             , GHC == 7.4.2
+             , GHC == 7.6.3
+             , GHC == 7.8.4
+             , GHC == 7.10.3
+             , GHC == 8.0.1
 extra-source-files:
   .travis.yml
   .ghci
@@ -98,13 +104,18 @@ library
       else
         build-depends: transformers >= 0.5 && < 0.6
 
-  if !flag(mtl)
-    cpp-options: -DHASKELL98
-  else
-    build-depends: ghc-prim
+  if flag(mtl)
+    cpp-options: -DMTL
+
+  if flag(generic-deriving)
     if impl(ghc < 8.0) && flag(generic-deriving)
       cpp-options: -DGENERIC_DERIVING
       build-depends: generic-deriving >= 1.10 && < 2
+
+  if !flag(mtl) && !flag(generic-deriving)
+    cpp-options: -DHASKELL98
+  else
+    build-depends: ghc-prim
 
   if flag(two)
     exposed-modules:


### PR DESCRIPTION
This PR:

* Adds the `-fgeneric-deriving` flag to `transformers-compat.cabal`. If enabled, then it will add `generic-deriving` as a dependency on GHC 7.10 and earlier
* If `generic-deriving` is a dependency, it will backport the `Generic(1)` instances to GHC 7.0, and backport the unlifted-type machinery in `Data.Functor.Classes.Generic` to GHC 7.10 and earlier.

I've tested this on GHC 7.0 through GHC 8.0 with various combinations of `-ftwo`, `-fthree`, and `-ffour`.