### PR TITLE
Backport changes from transformers-0.5.3 through 0.5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,16 +16,16 @@ matrix:
     - env: CABALVER=1.18 GHCVER=7.0.4
       compiler: ": #GHC 7.0.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS=-f-generic-deriving
+    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS="-f-generic-deriving"
       compiler: ": #GHC 7.0.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS=-f-mtl
+    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS="-f-mtl"
       compiler: ": #GHC 7.0.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.0.4 OPTS="-f-mtl -f-generic-deriving"
       compiler: ": #GHC 7.0.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS=-ftwo
+    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS="-ftwo"
       compiler: ": #GHC 7.0.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.0.4 OPTS="-ftwo -f-generic-deriving"
@@ -37,7 +37,7 @@ matrix:
     - env: CABALVER=1.18 GHCVER=7.0.4 OPTS="-ftwo -f-generic-deriving -f-mtl"
       compiler: ": #GHC 7.0.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS=-fthree
+    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS="-fthree"
       compiler: ": #GHC 7.0.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.0.4 OPTS="-fthree -f-generic-deriving"
@@ -49,7 +49,7 @@ matrix:
     - env: CABALVER=1.18 GHCVER=7.0.4 OPTS="-fthree -f-generic-deriving -f-mtl"
       compiler: ": #GHC 7.0.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS=-ffour
+    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS="-ffour"
       compiler: ": #GHC 7.0.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.0.4 OPTS="-ffour -f-generic-deriving"
@@ -61,61 +61,91 @@ matrix:
     - env: CABALVER=1.18 GHCVER=7.0.4 OPTS="-ffour -f-generic-deriving -f-mtl"
       compiler: ": #GHC 7.0.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS="-ffive"
+      compiler: ": #GHC 7.0.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS="-ffive -f-generic-deriving"
+      compiler: ": #GHC 7.0.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS="-ffive -f-mtl"
+      compiler: ": #GHC 7.0.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.0.4 OPTS="-ffive -f-generic-deriving -f-mtl"
+      compiler: ": #GHC 7.0.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.2.2
       compiler: ": #GHC 7.2.2"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-ftwo
+    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS="-ftwo"
       compiler: ": #GHC 7.2.2"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-fthree
+    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS="-fthree"
       compiler: ": #GHC 7.2.2"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS=-ffour
+    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS="-ffour"
+      compiler: ": #GHC 7.2.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.2.2 OPTS="-ffive"
       compiler: ": #GHC 7.2.2"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.4.2
       compiler: ": #GHC 7.4.2"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-ftwo
+    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS="-ftwo"
       compiler: ": #GHC 7.4.2"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-fthree
+    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS="-fthree"
       compiler: ": #GHC 7.4.2"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS=-ffour
+    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS="-ffour"
+      compiler: ": #GHC 7.4.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.4.2 OPTS="-ffive"
       compiler: ": #GHC 7.4.2"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.6.3
       compiler: ": #GHC 7.6.3"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-ftwo
+    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS="-ftwo"
       compiler: ": #GHC 7.6.3"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-fthree
+    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS="-fthree"
       compiler: ": #GHC 7.6.3"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS=-ffour
+    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS="-ffour"
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.6.3 OPTS="-ffive"
       compiler: ": #GHC 7.6.3"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-ftwo
+    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS="-ftwo"
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-fthree
+    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS="-fthree"
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS=-ffour
+    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS="-ffour"
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4 OPTS="-ffive"
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.22 GHCVER=7.10.3
       compiler: ": #GHC 7.10.3"
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,hlint], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.10.3 -ffour
+    - env: CABALVER=1.22 GHCVER=7.10.3 OPTS="-ffour"
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3 OPTS="-ffive"
       compiler: ": #GHC 7.10.3"
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.2
+      compiler: ": #GHC 8.0.2"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,hlint], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.2 OPTS="-ffive"
       compiler: ": #GHC 8.0.2"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,hlint], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=head
@@ -172,6 +202,7 @@ script:
  - cabal build   # this builds all libraries and executables (including tests)
  - hlint 0.2      --cpp-define HLINT
  - hlint 0.3      --cpp-define HLINT
+ - hlint 0.5      --cpp-define HLINT
  - hlint generics --cpp-define HLINT
  - hlint src      --cpp-define HLINT
  - cabal sdist # tests that a source-distribution can be generated

--- a/0.2/Data/Functor/Reverse.hs
+++ b/0.2/Data/Functor/Reverse.hs
@@ -30,6 +30,10 @@ import Data.Functor.Classes
 
 import Prelude hiding (foldr, foldr1, foldl, foldl1)
 import Control.Applicative
+import Control.Monad
+#if MIN_VERSION_base(4,9,0)
+import qualified Control.Monad.Fail as Fail
+#endif
 import Data.Foldable
 import Data.Traversable
 import Data.Monoid
@@ -77,6 +81,22 @@ instance (Alternative f) => Alternative (Reverse f) where
     {-# INLINE empty #-}
     Reverse x <|> Reverse y = Reverse (x <|> y)
     {-# INLINE (<|>) #-}
+
+-- | Derived instance.
+instance (Monad m) => Monad (Reverse m) where
+    return a = Reverse (return a)
+    {-# INLINE return #-}
+    m >>= f = Reverse (getReverse m >>= getReverse . f)
+    {-# INLINE (>>=) #-}
+    fail msg = Reverse (fail msg)
+    {-# INLINE fail #-}
+
+-- | Derived instance.
+instance (MonadPlus m) => MonadPlus (Reverse m) where
+    mzero = Reverse mzero
+    {-# INLINE mzero #-}
+    Reverse x `mplus` Reverse y = Reverse (x `mplus` y)
+    {-# INLINE mplus #-}
 
 -- | Fold from right to left.
 instance (Foldable f) => Foldable (Reverse f) where

--- a/0.3/Data/Functor/Classes.hs
+++ b/0.3/Data/Functor/Classes.hs
@@ -78,6 +78,9 @@ module Data.Functor.Classes (
 import Control.Applicative (Const(Const))
 import Data.Functor.Identity (Identity(Identity))
 import Data.Monoid (mappend)
+#if MIN_VERSION_base(4,7,0)
+import Data.Proxy (Proxy(Proxy))
+#endif
 import Text.Show (showListWith)
 
 import Control.Monad.Trans.Error
@@ -390,6 +393,21 @@ instance (Read a) => Read1 (Const a) where
     liftReadsPrec = liftReadsPrec2 readsPrec readList
 instance (Show a) => Show1 (Const a) where
     liftShowsPrec = liftShowsPrec2 showsPrec showList
+
+#if MIN_VERSION_base(4,7,0)
+instance Eq1 Proxy where
+    liftEq _ _ _ = True
+
+instance Ord1 Proxy where
+    liftCompare _ _ _ = EQ
+
+instance Show1 Proxy where
+    liftShowsPrec _ _ _ _ = showString "Proxy"
+
+instance Read1 Proxy where
+    liftReadsPrec _ _ d =
+        readParen (d > 10) (\r -> [(Proxy, s) | ("Proxy",s) <- lex r ])
+#endif
 
 -- Building blocks
 

--- a/0.5/Control/Monad/Trans/Accum.hs
+++ b/0.5/Control/Monad/Trans/Accum.hs
@@ -3,8 +3,10 @@
 #ifndef HASKELL98
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE StandaloneDeriving #-}
-# if __GLASGOW_HASKELL__ >= 702
+# if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE Safe #-}
+# elif __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Trustworthy #-}
 # endif
 # if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE PolyKinds #-}

--- a/0.5/Control/Monad/Trans/Accum.hs
+++ b/0.5/Control/Monad/Trans/Accum.hs
@@ -1,0 +1,307 @@
+{-# LANGUAGE CPP #-}
+
+#ifndef HASKELL98
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE StandaloneDeriving #-}
+# if __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Safe #-}
+# endif
+# if __GLASGOW_HASKELL__ >= 706
+{-# LANGUAGE PolyKinds #-}
+# endif
+# if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE AutoDeriveTypeable #-}
+{-# LANGUAGE DataKinds #-}
+# endif
+#endif
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Control.Monad.Trans.Accum
+-- Copyright   :  (c) Nickolay Kudasov 2016
+-- License     :  BSD-style (see the file LICENSE)
+--
+-- Maintainer  :  R.Paterson@city.ac.uk
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- The lazy 'AccumT' monad transformer, which adds accumulation
+-- capabilities (such as declarations or document patches) to a given monad.
+--
+-- This monad transformer provides append-only accumulation
+-- during the computation. For more general access, use
+-- "Control.Monad.Trans.State" instead.
+-----------------------------------------------------------------------------
+
+module Control.Monad.Trans.Accum (
+    -- * The Accum monad
+    Accum,
+    accum,
+    runAccum,
+    execAccum,
+    evalAccum,
+    mapAccum,
+    -- * The AccumT monad transformer
+    AccumT(AccumT),
+    runAccumT,
+    execAccumT,
+    evalAccumT,
+    mapAccumT,
+    -- * Accum operations
+    look,
+    looks,
+    add,
+    -- * Lifting other operations
+    liftCallCC,
+    liftCallCC',
+    liftCatch,
+    liftListen,
+    liftPass,
+    -- * Monad transformations
+    readerToAccumT,
+    writerToAccumT,
+    accumToStateT,
+  ) where
+
+import Control.Monad.IO.Class
+import Control.Monad.Trans.Class
+import Control.Monad.Trans.Reader (ReaderT(..))
+import Control.Monad.Trans.Writer (WriterT(..))
+import Control.Monad.Trans.State  (StateT(..))
+import Data.Functor.Identity
+
+import Control.Applicative
+import Control.Monad
+#if MIN_VERSION_base(4,9,0)
+import qualified Control.Monad.Fail as Fail
+#endif
+import Control.Monad.Fix
+import Control.Monad.Signatures
+#if !MIN_VERSION_base(4,8,0)
+import Data.Monoid
+#endif
+
+#if !defined(HASKELL98) && __GLASGOW_HASKELL__ >= 708
+import Data.Typeable
+#endif
+
+-- ---------------------------------------------------------------------------
+-- | An accumulation monad parameterized by the type @w@ of output to accumulate.
+--
+-- The 'return' function produces the output 'mempty', while @>>=@
+-- combines the outputs of the subcomputations using 'mappend'.
+type Accum w = AccumT w Identity
+
+-- | Construct an accumulation computation from a (result, output) pair.
+-- (The inverse of 'runAccum'.)
+accum :: (Monad m) => (w -> (a, w)) -> AccumT w m a
+accum f = AccumT $ \ w -> return (f w)
+{-# INLINE accum #-}
+
+-- | Unwrap an accumulation computation as a (result, output) pair.
+-- (The inverse of 'accum'.)
+runAccum :: Accum w a -> w -> (a, w)
+runAccum m = runIdentity . runAccumT m
+{-# INLINE runAccum #-}
+
+-- | Extract the output from an accumulation computation.
+--
+-- * @'execAccum' m w = 'snd' ('runAccum' m w)@
+execAccum :: Accum w a -> w -> w
+execAccum m w = snd (runAccum m w)
+{-# INLINE execAccum #-}
+
+-- | Evaluate an accumulation computation with the given initial output history
+-- and return the final value, discarding the final output.
+--
+-- * @'evalAccum' m w = 'fst' ('runAccum' m w)@
+evalAccum :: (Monoid w) => Accum w a -> w -> a
+evalAccum m w = fst (runAccum m w)
+{-# INLINE evalAccum #-}
+
+-- | Map both the return value and output of a computation using
+-- the given function.
+--
+-- * @'runAccum' ('mapAccum' f m) = f . 'runAccum' m@
+mapAccum :: ((a, w) -> (b, w)) -> Accum w a -> Accum w b
+mapAccum f = mapAccumT (Identity . f . runIdentity)
+{-# INLINE mapAccum #-}
+
+-- ---------------------------------------------------------------------------
+-- | An accumulation monad parameterized by:
+--
+--   * @w@ - the output to accumulate.
+--
+--   * @m@ - The inner monad.
+--
+-- The 'return' function produces the output 'mempty', while @>>=@
+-- combines the outputs of the subcomputations using 'mappend'.
+--
+-- This monad transformer is similar to both state and writer monad transformers.
+-- Thus it can be seen as
+--
+--  * a restricted append-only version of a state monad transformer or
+--
+--  * a writer monad transformer with the extra ability to read all previous output.
+newtype AccumT w m a = AccumT (w -> m (a, w))
+
+-- | Unwrap an accumulation computation.
+runAccumT :: AccumT w m a -> w -> m (a, w)
+runAccumT (AccumT f) = f
+{-# INLINE runAccumT #-}
+
+-- | Extract the output from an accumulation computation.
+--
+-- * @'execAccumT' m w = 'liftM' 'snd' ('runAccumT' m w)@
+execAccumT :: (Monad m) => AccumT w m a -> w -> m w
+execAccumT m w = do
+    ~(_, w') <- runAccumT m w
+    return w'
+{-# INLINE execAccumT #-}
+
+-- | Evaluate an accumulation computation with the given initial output history
+-- and return the final value, discarding the final output.
+--
+-- * @'evalAccumT' m w = 'liftM' 'fst' ('runAccumT' m w)@
+evalAccumT :: (Monad m, Monoid w) => AccumT w m a -> w -> m a
+evalAccumT m w = do
+    ~(a, _) <- runAccumT m w
+    return a
+{-# INLINE evalAccumT #-}
+
+-- | Map both the return value and output of a computation using
+-- the given function.
+--
+-- * @'runAccumT' ('mapAccumT' f m) = f . 'runAccumT' m@
+mapAccumT :: (m (a, w) -> n (b, w)) -> AccumT w m a -> AccumT w n b
+mapAccumT f m = AccumT (f . runAccumT m)
+{-# INLINE mapAccumT #-}
+
+instance (Functor m) => Functor (AccumT w m) where
+    fmap f = mapAccumT $ fmap $ \ ~(a, w) -> (f a, w)
+    {-# INLINE fmap #-}
+
+instance (Monoid w, Functor m, Monad m) => Applicative (AccumT w m) where
+    pure a  = AccumT $ const $ return (a, mempty)
+    {-# INLINE pure #-}
+    mf <*> mv = AccumT $ \ w -> do
+      ~(f, w')  <- runAccumT mf w
+      ~(v, w'') <- runAccumT mv (w `mappend` w')
+      return (f v, w' `mappend` w'')
+    {-# INLINE (<*>) #-}
+
+instance (Monoid w, Functor m, MonadPlus m) => Alternative (AccumT w m) where
+    empty   = AccumT $ const mzero
+    {-# INLINE empty #-}
+    m <|> n = AccumT $ \ w -> runAccumT m w `mplus` runAccumT n w
+    {-# INLINE (<|>) #-}
+
+instance (Monoid w, Functor m, Monad m) => Monad (AccumT w m) where
+#if !(MIN_VERSION_base(4,8,0))
+    return a  = AccumT $ const $ return (a, mempty)
+    {-# INLINE return #-}
+#endif
+    m >>= k  = AccumT $ \ w -> do
+        ~(a, w')  <- runAccumT m w
+        ~(b, w'') <- runAccumT (k a) (w `mappend` w')
+        return (b, w' `mappend` w'')
+    {-# INLINE (>>=) #-}
+    fail msg = AccumT $ const (fail msg)
+    {-# INLINE fail #-}
+
+#if MIN_VERSION_base(4,9,0)
+instance (Monoid w, Fail.MonadFail m) => Fail.MonadFail (AccumT w m) where
+    fail msg = AccumT $ const (Fail.fail msg)
+    {-# INLINE fail #-}
+#endif
+
+instance (Monoid w, Functor m, MonadPlus m) => MonadPlus (AccumT w m) where
+    mzero       = AccumT $ const mzero
+    {-# INLINE mzero #-}
+    m `mplus` n = AccumT $ \ w -> runAccumT m w `mplus` runAccumT n w
+    {-# INLINE mplus #-}
+
+instance (Monoid w, Functor m, MonadFix m) => MonadFix (AccumT w m) where
+    mfix m = AccumT $ \ w -> mfix $ \ ~(a, _) -> runAccumT (m a) w
+    {-# INLINE mfix #-}
+
+instance (Monoid w) => MonadTrans (AccumT w) where
+    lift m = AccumT $ const $ do
+        a <- m
+        return (a, mempty)
+    {-# INLINE lift #-}
+
+instance (Monoid w, Functor m, MonadIO m) => MonadIO (AccumT w m) where
+    liftIO = lift . liftIO
+    {-# INLINE liftIO #-}
+
+#if !defined(HASKELL98) && __GLASGOW_HASKELL__ >= 708
+deriving instance Typeable AccumT
+#endif
+
+-- | @'look'@ is an action that fetches all the previously accumulated output.
+look :: (Monoid w, Monad m) => AccumT w m w
+look = AccumT $ \ w -> return (w, mempty)
+
+-- | @'look'@ is an action that retrieves a function of the previously accumulated output.
+looks :: (Monoid w, Monad m) => (w -> a) -> AccumT w m a
+looks f = AccumT $ \ w -> return (f w, mempty)
+
+-- | @'add' w@ is an action that produces the output @w@.
+add :: (Monad m) => w -> AccumT w m ()
+add w = accum $ const ((), w)
+{-# INLINE add #-}
+
+-- | Uniform lifting of a @callCC@ operation to the new monad.
+-- This version rolls back to the original output history on entering the
+-- continuation.
+liftCallCC :: CallCC m (a, w) (b, w) -> CallCC (AccumT w m) a b
+liftCallCC callCC f = AccumT $ \ w ->
+    callCC $ \ c ->
+    runAccumT (f (\ a -> AccumT $ \ _ -> c (a, w))) w
+{-# INLINE liftCallCC #-}
+
+-- | In-situ lifting of a @callCC@ operation to the new monad.
+-- This version uses the current output history on entering the continuation.
+-- It does not satisfy the uniformity property (see "Control.Monad.Signatures").
+liftCallCC' :: CallCC m (a, w) (b, w) -> CallCC (AccumT w m) a b
+liftCallCC' callCC f = AccumT $ \ s ->
+    callCC $ \ c ->
+    runAccumT (f (\ a -> AccumT $ \ s' -> c (a, s'))) s
+{-# INLINE liftCallCC' #-}
+
+-- | Lift a @catchE@ operation to the new monad.
+liftCatch :: Catch e m (a, w) -> Catch e (AccumT w m) a
+liftCatch catchE m h =
+    AccumT $ \ w -> runAccumT m w `catchE` \ e -> runAccumT (h e) w
+{-# INLINE liftCatch #-}
+
+-- | Lift a @listen@ operation to the new monad.
+liftListen :: (Monad m) => Listen w m (a, s) -> Listen w (AccumT s m) a
+liftListen listen m = AccumT $ \ s -> do
+    ~((a, s'), w) <- listen (runAccumT m s)
+    return ((a, w), s')
+{-# INLINE liftListen #-}
+
+-- | Lift a @pass@ operation to the new monad.
+liftPass :: (Monad m) => Pass w m (a, s) -> Pass w (AccumT s m) a
+liftPass pass m = AccumT $ \ s -> pass $ do
+    ~((a, f), s') <- runAccumT m s
+    return ((a, s'), f)
+{-# INLINE liftPass #-}
+
+-- | Convert a read-only computation into an accumulation computation.
+readerToAccumT :: (Functor m, Monoid w) => ReaderT w m a -> AccumT w m a
+readerToAccumT (ReaderT f) = AccumT $ \ w -> fmap (\ a -> (a, mempty)) (f w)
+{-# INLINE readerToAccumT #-}
+
+-- | Convert a writer computation into an accumulation computation.
+writerToAccumT :: WriterT w m a -> AccumT w m a
+writerToAccumT (WriterT m) = AccumT $ const $ m
+{-# INLINE writerToAccumT #-}
+
+-- | Convert an accumulation (append-only) computation into a fully
+-- stateful computation.
+accumToStateT :: (Functor m, Monoid s) => AccumT s m a -> StateT s m a
+accumToStateT (AccumT f) =
+    StateT $ \ w -> fmap (\ ~(a, w') -> (a, w `mappend` w')) (f w)
+{-# INLINE accumToStateT #-}

--- a/0.5/Control/Monad/Trans/Select.hs
+++ b/0.5/Control/Monad/Trans/Select.hs
@@ -3,8 +3,10 @@
 # ifndef HASKELL98
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE StandaloneDeriving #-}
-#if __GLASGOW_HASKELL__ >= 702
+# if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE Safe #-}
+# elif __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Trustworthy #-}
 # endif
 # if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE PolyKinds #-}

--- a/0.5/Control/Monad/Trans/Select.hs
+++ b/0.5/Control/Monad/Trans/Select.hs
@@ -1,0 +1,147 @@
+{-# LANGUAGE CPP #-}
+
+# ifndef HASKELL98
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE StandaloneDeriving #-}
+#if __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Safe #-}
+# endif
+# if __GLASGOW_HASKELL__ >= 706
+{-# LANGUAGE PolyKinds #-}
+# endif
+# if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE AutoDeriveTypeable #-}
+{-# LANGUAGE DataKinds #-}
+# endif
+#endif
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Control.Monad.Trans.Select
+-- Copyright   :  (c) Ross Paterson 2017
+-- License     :  BSD-style (see the file LICENSE)
+--
+-- Maintainer  :  R.Paterson@city.ac.uk
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- Selection monad transformer, modelling search algorithms.
+--
+-- * Martin Escardo and Paulo Oliva.
+--   "Selection functions, bar recursion and backward induction",
+--   /Mathematical Structures in Computer Science/ 20:2 (2010), pp. 127-168.
+--   <https://www.cs.bham.ac.uk/~mhe/papers/selection-escardo-oliva.pdf>
+--
+-- * Jules Hedges. "Monad transformers for backtracking search".
+--   In /Proceedings of MSFP 2014/. <https://arxiv.org/abs/1406.2058>
+-----------------------------------------------------------------------------
+
+module Control.Monad.Trans.Select (
+    -- * The Select monad
+    Select,
+    select,
+    runSelect,
+    -- * The SelectT monad transformer
+    SelectT(SelectT),
+    runSelectT,
+    selectToCont,
+    ) where
+
+import Control.Monad.IO.Class
+import Control.Monad.Trans.Class
+import Control.Monad.Trans.Cont
+
+import Control.Applicative
+import Control.Monad
+#if MIN_VERSION_base(4,9,0)
+import qualified Control.Monad.Fail as Fail
+#endif
+import Data.Functor.Identity
+
+#if !defined(HASKELL98) && __GLASGOW_HASKELL__ >= 708
+import Data.Typeable
+#endif
+
+-- | Selection monad.
+type Select r = SelectT r Identity
+
+-- | Constructor for computations in the selection monad.
+select :: ((a -> r) -> a) -> Select r a
+select f = SelectT $ \ k -> Identity (f (runIdentity . k))
+{-# INLINE select #-}
+
+-- | Runs a @Select@ computation with a function for evaluating answers
+-- to select a particular answer.  (The inverse of 'select'.)
+runSelect :: Select r a -> (a -> r) -> a
+runSelect m k = runIdentity (runSelectT m (Identity . k))
+{-# INLINE runSelect #-}
+
+-- | Selection monad transformer.
+--
+-- 'SelectT' is not a functor on the category of monads, and many operations
+-- cannot be lifted through it.
+newtype SelectT r m a = SelectT ((a -> m r) -> m a)
+
+-- | Runs a @SelectT@ computation with a function for evaluating answers
+-- to select a particular answer.  (The inverse of 'select'.)
+runSelectT :: SelectT r m a -> (a -> m r) -> m a
+runSelectT (SelectT g) = g
+{-# INLINE runSelectT #-}
+
+instance (Functor m) => Functor (SelectT r m) where
+    fmap f (SelectT g) = SelectT (fmap f . g . (. f))
+    {-# INLINE fmap #-}
+
+instance (Functor m, Monad m) => Applicative (SelectT r m) where
+    pure = lift . return
+    {-# INLINE pure #-}
+    SelectT gf <*> SelectT gx = SelectT $ \ k -> do
+        let h f = liftM f (gx (k . f))
+        f <- gf ((>>= k) . h)
+        h f
+    {-# INLINE (<*>) #-}
+
+instance (Functor m, MonadPlus m) => Alternative (SelectT r m) where
+    empty = mzero
+    {-# INLINE empty #-}
+    (<|>) = mplus
+    {-# INLINE (<|>) #-}
+
+instance (Monad m) => Monad (SelectT r m) where
+#if !(MIN_VERSION_base(4,8,0))
+    return = lift . return
+    {-# INLINE return #-}
+#endif
+    SelectT g >>= f = SelectT $ \ k -> do
+        let h x = runSelectT (f x) k
+        y <- g ((>>= k) . h)
+        h y
+    {-# INLINE (>>=) #-}
+
+#if MIN_VERSION_base(4,9,0)
+instance (Fail.MonadFail m) => Fail.MonadFail (SelectT r m) where
+    fail msg = lift (Fail.fail msg)
+    {-# INLINE fail #-}
+#endif
+
+instance (MonadPlus m) => MonadPlus (SelectT r m) where
+    mzero = SelectT (const mzero)
+    {-# INLINE mzero #-}
+    SelectT f `mplus` SelectT g = SelectT $ \ k -> f k `mplus` g k
+    {-# INLINE mplus #-}
+
+instance MonadTrans (SelectT r) where
+    lift = SelectT . const
+    {-# INLINE lift #-}
+
+instance (MonadIO m) => MonadIO (SelectT r m) where
+    liftIO = lift . liftIO
+    {-# INLINE liftIO #-}
+
+#if !defined(HASKELL98) && __GLASGOW_HASKELL__ >= 708
+deriving instance Typeable SelectT
+#endif
+
+-- | Convert a selection computation to a continuation-passing computation.
+selectToCont :: (Monad m) => SelectT r m a -> ContT r m a
+selectToCont (SelectT g) = ContT $ \ k -> g k >>= k
+{-# INLINE selectToCont #-}

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -3,6 +3,13 @@ next
 * Introduce the `Data.Functor.Classes.Generic` module, which provides functions that can generically implement methods in the `Eq1`, `Ord1`, `Read1`, and `Show1` classes (without the usual boilerplate involved).
 * Introduce the `generic-deriving` flag. When enabled, `transformers-compat` will depend on the `generic-deriving` library on older versions of GHC to backport `GHC.Generics` support for `Generic` instances and the machinery in `Data.Functor.Classes.Generic`.
 * Some instances were present in `Data.Functor.Sum` but not in `Control.Monad.Trans.Instances` (e.g., the `Generic`, `Typeable`, and `Data` instances for `Sum`). This has been fixed.
+* Backport changes from `transformers-0.5.4` (i.e., add `Bifoldable` and `Bitraversable` instances for `Data.Functor.Constant`)
+* Backport changes from `transformers-0.5.3`:
+  * Backport the `Control.Monad.Trans.Accum` and `Control.Monad.Trans.Select` modules
+  * Backport the `eitherToErrors` and `elimLift` functions to `Control.Applicative.Lift`
+  * Backport `Bits`, `FiniteBits`, `IsString`, `Num`, `Real`, `Integral`, `Fractional`, `Floating`, `RealFrac`, and `RealFloat` instances for `Data.Functor.Identity`
+  * Backport `Monad`, `MonadFail`, and `MonadPlus` instances for `Data.Functor.Reverse`
+  * Backport `Eq1`, `Ord1`, `Read1`, and `Show1` instances for `Data.Proxy`
 * Backport changes from `transformers-0.5.2` (i.e., add more `INLINE` annotations)
 * Backport changes from `transformers-0.5.1` (i.e., add `Bounded`, `Enum`, `Ix`, and `Storable` instances for `Identity`)
 

--- a/src/Control/Monad/Trans/Instances.hs
+++ b/src/Control/Monad/Trans/Instances.hs
@@ -385,7 +385,9 @@ instance Read1 Proxy where
         readParen (d > 10) (\r -> [(Proxy, s) | ("Proxy",s) <- lex r ])
 #   endif
 #  endif
+# endif
 
+# if !(MIN_VERSION_base(4,8,0))
 -- Data.Functor.Identity
 instance (Bits a) => Bits (Identity a) where
     Identity x .&. Identity y     = Identity (x .&. y)

--- a/transformers-compat.cabal
+++ b/transformers-compat.cabal
@@ -59,6 +59,11 @@ flag four
   manual: True
   description: Use transformers 0.4. This will be selected by cabal picking the appropriate version.
 
+flag five
+  default: False
+  manual: True
+  description: Use transformers 0.5 up until (but not including) 0.5.3. This will be selected by cabal picking the appropriate version.
+
 flag mtl
   default: True
   manual: True
@@ -86,23 +91,28 @@ library
   other-modules:
     Paths_transformers_compat
 
-  if flag(four)
-    cpp-options: -DTRANSFORMERS_FOUR
-    build-depends: transformers >= 0.4 && < 0.5
+  if flag(five)
+    hs-source-dirs: 0.5
+    build-depends: transformers >= 0.5 && < 0.5.3
   else
-    if flag(three)
-      hs-source-dirs: 0.3
-      build-depends: transformers >= 0.3 && < 0.4
-      if flag(mtl)
-        build-depends: mtl >= 2.1 && < 2.2
+    if flag(four)
+      cpp-options: -DTRANSFORMERS_FOUR
+      hs-source-dirs: 0.5
+      build-depends: transformers >= 0.4 && < 0.5
     else
-      if flag(two)
-        hs-source-dirs: 0.2 0.3
-        build-depends: transformers >= 0.2 && < 0.3
+      if flag(three)
+        hs-source-dirs: 0.3 0.5
+        build-depends: transformers >= 0.3 && < 0.4
         if flag(mtl)
-          build-depends: mtl >= 2.0 && < 2.1
+          build-depends: mtl >= 2.1 && < 2.2
       else
-        build-depends: transformers >= 0.5 && < 0.6
+        if flag(two)
+          hs-source-dirs: 0.2 0.3 0.5
+          build-depends: transformers >= 0.2 && < 0.3
+          if flag(mtl)
+            build-depends: mtl >= 2.0 && < 2.1
+        else
+          build-depends: transformers >= 0.5.3 && < 0.6
 
   if impl(ghc >= 7.2) || flag(generic-deriving)
     hs-source-dirs: generics
@@ -131,6 +141,11 @@ library
       Control.Monad.Signatures
       Data.Functor.Classes
       Data.Functor.Sum
+
+  if flag(two) || flag(three) || flag(five)
+    exposed-modules:
+      Control.Monad.Trans.Accum
+      Control.Monad.Trans.Select
 
   if impl(ghc >= 7.2) || flag(generic-deriving)
     exposed-modules:


### PR DESCRIPTION
`transformers-0.5.3` (and `0.5.4`, which adds some minor fixes) were just released, which incorporate some major additions. This PR adds them to `transformers-compat`:

* This backports the `Control.Monad.Trans.Accum` and `Control.Monad.Trans.Select` modules, which are two new monad transformers introduced in 0.5.3. They are guarded with the new `five` flag, which is a bit of a misnomer, sadly, as "`five`" only applies up until 0.5.3. But I can't think of a better name.
* This also backports several instances which were added in 0.5.3 and 0.5.4. Refer to the changelog for details.