### PR TITLE
8.4 compat: Semigroup Constant is in base, so we don't need to define it. 

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -17,6 +17,8 @@ next
   * Backport `Eq1`, `Ord1`, `Read1`, and `Show1` instances for `Data.Proxy`
 * Backport changes from `transformers-0.5.2` (i.e., add more `INLINE` annotations)
 * Backport changes from `transformers-0.5.1` (i.e., add `Bounded`, `Enum`, `Ix`, and `Storable` instances for `Identity`)
+* GHC 8.4 compatibility:
+  * The `Semigroup` instance for `Constant` is now defined in `base`, so we have no need to define it on GHC 8.4 and above.
 
 0.5.1.4
 -------

--- a/src/Control/Monad/Trans/Instances.hs
+++ b/src/Control/Monad/Trans/Instances.hs
@@ -532,7 +532,7 @@ instance Bitraversable Constant where
 #endif
 
 #if !(MIN_VERSION_transformers(0,5,5))
-# if MIN_VERSION_base(4,9,0)
+# if MIN_VERSION_base(4,9,0) && !(MIN_VERSION_base(4,12,0))
 instance (Semigroup.Semigroup a) => Semigroup.Semigroup (Constant a b) where
     Constant x <> Constant y = Constant (x Semigroup.<> y)
     {-# INLINE (<>) #-}


### PR DESCRIPTION
Not sure if this is the only change that'll have to be made; I'll watch Travis and see what it thinks.