### PR TITLE
 Migrate tests to separate .cabal file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -226,7 +226,7 @@ install:
       (cd "./tests" && autoreconf -i);
     fi
   - rm -f cabal.project.freeze
-  - cabal new-build -w ${HC} ${CABALFLAGS} ${TEST} ${BENCH} --project-file="cabal.project" --dep -j2 all
+  - cabal new-build -w ${HC} ${CABALFLAGS} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep -j2 all
   - rm -rf .ghc.environment.* "."/dist "./tests"/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,61 +44,61 @@ matrix:
     - compiler: "ghc-7.0.4"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
-      env: CABALFLAGS="-f-generic-deriving"
+      env: CABALFLAGS="-f-generic-deriving -f-tests"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
       env: CABALFLAGS="-f-mtl"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
-      env: CABALFLAGS="-f-generic-deriving -f-mtl"
+      env: CABALFLAGS="-f-generic-deriving -f-mtl -f-tests"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
       env: CABALFLAGS="-ftwo"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
-      env: CABALFLAGS="-ftwo -f-generic-deriving"
+      env: CABALFLAGS="-ftwo -f-generic-deriving -f-tests"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
       env: CABALFLAGS="-ftwo -f-mtl"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
-      env: CABALFLAGS="-ftwo -f-generic-deriving -f-mtl"
+      env: CABALFLAGS="-ftwo -f-generic-deriving -f-mtl -f-tests"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
       env: CABALFLAGS="-fthree"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
-      env: CABALFLAGS="-fthree -f-generic-deriving"
+      env: CABALFLAGS="-fthree -f-generic-deriving -f-tests"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
       env: CABALFLAGS="-fthree -f-mtl"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
-      env: CABALFLAGS="-fthree -f-generic-deriving -f-mtl"
+      env: CABALFLAGS="-fthree -f-generic-deriving -f-mtl -f-tests"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
       env: CABALFLAGS="-ffour"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
-      env: CABALFLAGS="-ffour -f-generic-deriving"
+      env: CABALFLAGS="-ffour -f-generic-deriving -f-tests"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
       env: CABALFLAGS="-ffour -f-mtl"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
-      env: CABALFLAGS="-ffour -f-generic-deriving -f-mtl"
+      env: CABALFLAGS="-ffour -f-generic-deriving -f-mtl -f-tests"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
       env: CABALFLAGS="-ffive"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
-      env: CABALFLAGS="-ffive -f-generic-deriving"
+      env: CABALFLAGS="-ffive -f-generic-deriving -f-tests"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
       env: CABALFLAGS="-ffive -f-mtl"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
-      env: CABALFLAGS="-ffive -f-generic-deriving -f-mtl"
+      env: CABALFLAGS="-ffive -f-generic-deriving -f-mtl -f-tests"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.2.2"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.2.2], sources: [hvr-ghc]}}

--- a/.travis.yml
+++ b/.travis.yml
@@ -194,7 +194,7 @@ install:
   - cabal --version
   - echo "$(${HC} --version) [$(${HC} --print-project-git-commit-id 2> /dev/null || echo '?')]"
   - BENCH=${BENCH---enable-benchmarks}
-  - TEST=${TEST---disable-tests} # https://github.com/ekmett/transformers-compat/issues/24
+  - TEST=${TEST---enable-tests}
   - HADDOCK=${HADDOCK-true}
   - INSTALLED=${INSTALLED-true}
   - GHCHEAD=${GHCHEAD-false}
@@ -217,14 +217,17 @@ install:
       cabal new-update head.hackage -v
     fi
   - grep -Ev -- '^\s*--' ${HOME}/.cabal/config | grep -Ev '^\s*$'
-  - "printf 'packages: \".\"\\n' > cabal.project"
+  - "printf 'packages: \".\" \"./tests\"\\n' > cabal.project"
   - cat cabal.project
   - if [ -f "./configure.ac" ]; then
       (cd "." && autoreconf -i);
     fi
+  - if [ -f "./tests/configure.ac" ]; then
+      (cd "./tests" && autoreconf -i);
+    fi
   - rm -f cabal.project.freeze
   - cabal new-build -w ${HC} ${CABALFLAGS} ${TEST} ${BENCH} --project-file="cabal.project" --dep -j2 all
-  - rm -rf "."/.ghc.environment.* "."/dist
+  - rm -rf .ghc.environment.* "."/dist "./tests"/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
 
 # Here starts the actual work to be performed for the package under test;
@@ -232,10 +235,11 @@ install:
 script:
   # test that source-distributions can be generated
   - (cd "." && cabal sdist)
-  - mv "."/dist/transformers-compat-*.tar.gz ${DISTDIR}/
+  - (cd "./tests" && cabal sdist)
+  - mv "."/dist/transformers-compat-*.tar.gz "./tests"/dist/transformers-compat-tests-*.tar.gz ${DISTDIR}/
   - cd ${DISTDIR} || false
   - find . -maxdepth 1 -name '*.tar.gz' -exec tar -xvf '{}' \;
-  - "printf 'packages: transformers-compat-*/*.cabal\\n' > cabal.project"
+  - "printf 'packages: transformers-compat-*/*.cabal transformers-compat-tests-*/*.cabal\\n' > cabal.project"
   - cat cabal.project
 
 
@@ -245,6 +249,7 @@ script:
 
   # cabal check
   - (cd transformers-compat-* && cabal check)
+  - (cd transformers-compat-tests-* && cabal check)
 
   # haddock
   - rm -rf ./dist-newstyle

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,61 +44,61 @@ matrix:
     - compiler: "ghc-7.0.4"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
-      env: CABALFLAGS="-f-generic-deriving -f-tests"
+      env: CABALFLAGS="-f-generic-deriving" TEST=--disable-tests
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
       env: CABALFLAGS="-f-mtl"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
-      env: CABALFLAGS="-f-generic-deriving -f-mtl -f-tests"
+      env: CABALFLAGS="-f-generic-deriving -f-mtl" TEST=--disable-tests
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
       env: CABALFLAGS="-ftwo"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
-      env: CABALFLAGS="-ftwo -f-generic-deriving -f-tests"
+      env: CABALFLAGS="-ftwo -f-generic-deriving" TEST=--disable-tests
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
       env: CABALFLAGS="-ftwo -f-mtl"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
-      env: CABALFLAGS="-ftwo -f-generic-deriving -f-mtl -f-tests"
+      env: CABALFLAGS="-ftwo -f-generic-deriving -f-mtl" TEST=--disable-tests
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
       env: CABALFLAGS="-fthree"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
-      env: CABALFLAGS="-fthree -f-generic-deriving -f-tests"
+      env: CABALFLAGS="-fthree -f-generic-deriving" TEST=--disable-tests
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
       env: CABALFLAGS="-fthree -f-mtl"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
-      env: CABALFLAGS="-fthree -f-generic-deriving -f-mtl -f-tests"
+      env: CABALFLAGS="-fthree -f-generic-deriving -f-mtl" TEST=--disable-tests
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
       env: CABALFLAGS="-ffour"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
-      env: CABALFLAGS="-ffour -f-generic-deriving -f-tests"
+      env: CABALFLAGS="-ffour -f-generic-deriving" TEST=--disable-tests
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
       env: CABALFLAGS="-ffour -f-mtl"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
-      env: CABALFLAGS="-ffour -f-generic-deriving -f-mtl -f-tests"
+      env: CABALFLAGS="-ffour -f-generic-deriving -f-mtl" TEST=--disable-tests
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
       env: CABALFLAGS="-ffive"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
-      env: CABALFLAGS="-ffive -f-generic-deriving -f-tests"
+      env: CABALFLAGS="-ffive -f-generic-deriving" TEST=--disable-tests
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
       env: CABALFLAGS="-ffive -f-mtl"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.0.4"
-      env: CABALFLAGS="-ffive -f-generic-deriving -f-mtl -f-tests"
+      env: CABALFLAGS="-ffive -f-generic-deriving -f-mtl" TEST=--disable-tests
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.2.2"
       addons: {apt: {packages: [*apt_packages,cabal-install-2.0,ghc-7.2.2], sources: [hvr-ghc]}}
@@ -226,7 +226,6 @@ install:
       (cd "./tests" && autoreconf -i);
     fi
   - rm -f cabal.project.freeze
-  - cabal new-build -w ${HC} ${CABALFLAGS} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep -j2 all
   - rm -rf .ghc.environment.* "."/dist "./tests"/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
 
@@ -244,7 +243,7 @@ script:
 
 
   # build & run tests, build benchmarks
-  - cabal new-build -w ${HC} ${CABALFLAGS} ${TEST} ${BENCH} all
+  - cabal new-build -w ${HC} ${CABALFLAGS} ${TEST} ${BENCH} -j2 all
   - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${CABALFLAGS} ${TEST} ${BENCH} all; fi
 
   # cabal check

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,2 @@
 packages: .
+          ./tests

--- a/tests/GenericsTypes.hs
+++ b/tests/GenericsTypes.hs
@@ -138,6 +138,10 @@ $(deriveAll1 ''Prim)
 #define CLASS1_INSTANCE(class,type,method,impl) \
 instance class type where { method = impl };    \
 
+#if MIN_VERSION_transformers(0,4,0) && !(MIN_VERSION_transformers(0,5,0))
+# define TRANSFORMERS_FOUR 1
+#endif
+
 #if defined(TRANSFORMERS_FOUR)
 # define EQ1_INSTANCE(type)   CLASS1_INSTANCE(Eq1,type,eq1,eq1Default)
 # define ORD1_INSTANCE(type)  CLASS1_INSTANCE(Ord1,type,compare1,compare1Default)

--- a/tests/GenericsTypes.hs
+++ b/tests/GenericsTypes.hs
@@ -29,7 +29,7 @@ import GHC.Exts
 
 import Test.QuickCheck (Arbitrary(..), oneof)
 
-#if __GLASGOW_HASKELL__ < 702
+#if __GLASGOW_HASKELL__ == 700 || __GLASGOW_HASKELL__ == 804
 import Text.Read.Deriving (deriveRead)
 #endif
 
@@ -105,11 +105,14 @@ instance Arbitrary a => Arbitrary (Record a) where
                     , (:%:)  <$> arbitrary <*> arbitrary
                     ]
 
-#if __GLASGOW_HASKELL__ >= 702
-deriving instance Read a => Read (T# a)
-#else
+#if __GLASGOW_HASKELL__ == 700
 -- Workaround for GHC Trac #5041
 $(deriveRead ''T#)
+#elif __GLASGOW_HASKELL__ == 804
+-- Workaround for GHC Trac #14918
+$(deriveRead ''T#)
+#else
+deriving instance Read a => Read (T# a)
 #endif
 
 #if __GLASGOW_HASKELL__ >= 706

--- a/tests/LICENSE
+++ b/tests/LICENSE
@@ -1,0 +1,30 @@
+Copyright 2012-2015 Edward Kmett
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the author nor the names of his contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/tests/transformers-compat-tests.cabal
+++ b/tests/transformers-compat-tests.cabal
@@ -1,0 +1,45 @@
+name:          transformers-compat-tests
+category:      Compatibility
+version:       0.1
+license:       BSD3
+cabal-version: >= 1.8
+license-file:  LICENSE
+author:        Edward A. Kmett
+maintainer:    Edward A. Kmett <ekmett@gmail.com>
+stability:     provisional
+homepage:      http://github.com/ekmett/transformers-compat/
+bug-reports:   http://github.com/ekmett/transformers-compat/issues
+copyright:     Copyright (C) 2012-2015 Edward A. Kmett
+synopsis:      transformers-compat tests
+description:   @transformers-copmat@ tests
+build-type:    Simple
+tested-with:   GHC == 7.0.4
+             , GHC == 7.2.2
+             , GHC == 7.4.2
+             , GHC == 7.6.3
+             , GHC == 7.8.4
+             , GHC == 7.10.3
+             , GHC == 8.0.2
+             , GHC == 8.2.2
+             , GHC == 8.4.1
+
+source-repository head
+  type: git
+  location: git://github.com/ekmett/transformers-compat.git
+
+test-suite spec
+  type:                 exitcode-stdio-1.0
+  main-is:              Spec.hs
+  other-modules:        GenericsSpec
+                        GenericsTypes
+  build-depends:        base             >= 4.3   && < 5
+                      , deriving-compat  >= 0.3.4 && < 1
+                      , generic-deriving >= 1.10  && < 2
+                      , hspec            >= 2     && < 3
+                      , QuickCheck       >= 2     && < 3
+                      , tagged           >= 0.7   && < 1
+                      , transformers     >= 0.2   && < 0.6
+                      , transformers-compat
+  build-tool-depends:   hspec-discover:hspec-discover >= 2 && < 3
+  hs-source-dirs:       .
+  ghc-options:          -Wall -threaded -rtsopts

--- a/tests/transformers-compat-tests.cabal
+++ b/tests/transformers-compat-tests.cabal
@@ -27,7 +27,14 @@ source-repository head
   type: git
   location: git://github.com/ekmett/transformers-compat.git
 
+flag tests
+  default: True
+  description: Enable the tests.
+
 test-suite spec
+  if !flag(tests)
+    buildable:          False
+
   type:                 exitcode-stdio-1.0
   main-is:              Spec.hs
   other-modules:        GenericsSpec

--- a/transformers-compat.cabal
+++ b/transformers-compat.cabal
@@ -39,7 +39,7 @@ extra-source-files:
   .vim.custom
   config
   tests/*.hs
-  tests/LICENCE
+  tests/LICENSE
   tests/transformers-compat-tests.cabal
   HLint.hs
   README.markdown

--- a/transformers-compat.cabal
+++ b/transformers-compat.cabal
@@ -38,6 +38,9 @@ extra-source-files:
   .gitignore
   .vim.custom
   config
+  tests/*.hs
+  tests/LICENCE
+  tests/transformers-compat-tests.cabal
   HLint.hs
   README.markdown
   CHANGELOG.markdown
@@ -153,28 +156,3 @@ library
     exposed-modules:
       Data.Functor.Classes.Generic
       Data.Functor.Classes.Generic.Internal
-
-test-suite spec
-  if !impl(ghc >= 8.0) && !flag(generic-deriving)
-    buildable:          False
-
-  type:                 exitcode-stdio-1.0
-  main-is:              Spec.hs
-  other-modules:        GenericsSpec
-                        GenericsTypes
-  build-depends:        base             >= 4.3   && < 5
-                      , deriving-compat  >= 0.3.4 && < 1
-                      , hspec            >= 2     && < 3
-                      , QuickCheck       >= 2     && < 3
-                      , tagged           >= 0.7   && < 1
-                      , transformers     >= 0.2   && < 0.6
-                      , transformers-compat
-
-  if !impl(ghc >= 8.0)
-    build-depends:      generic-deriving >= 1.10  && < 2
-
-  if flag(four)
-    cpp-options:        -DTRANSFORMERS_FOUR
-
-  hs-source-dirs:       tests
-  ghc-options:          -Wall -threaded -rtsopts


### PR DESCRIPTION
This is a useful hack that lets us build the library and tests all in one go. More importantly, we can actually _run_ the tests on Travis now, fixing #24.