### PR TITLE
Support transformers-0.6.*

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,40 +8,15 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.12
+# version: 0.12.1
 #
-# REGENDATA ("0.12",["github","cabal.project"])
+# REGENDATA ("0.12.1",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
   - push
   - pull_request
 jobs:
-  irc:
-    name: Haskell-CI (IRC notification)
-    runs-on: ubuntu-18.04
-    needs:
-      - linux
-    if: ${{ always() && (github.repository == 'ekmett/transformers-compat') }}
-    strategy:
-      fail-fast: false
-    steps:
-      - name: IRC success notification (irc.freenode.org#haskell-lens)
-        uses: Gottox/irc-message-action@v1.1
-        if: needs.linux.result == 'success'
-        with:
-          channel: "#haskell-lens"
-          message: "\x0313transformers-compat\x03/\x0306${{ github.ref }}\x03 \x0314${{ github.sha }}\x03 https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} The build succeeded."
-          nickname: github-actions
-          server: irc.freenode.org
-      - name: IRC failure notification (irc.freenode.org#haskell-lens)
-        uses: Gottox/irc-message-action@v1.1
-        if: needs.linux.result != 'success'
-        with:
-          channel: "#haskell-lens"
-          message: "\x0313transformers-compat\x03/\x0306${{ github.ref }}\x03 \x0314${{ github.sha }}\x03 https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} The build failed."
-          nickname: github-actions
-          server: irc.freenode.org
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-18.04

--- a/0.2/Control/Applicative/Backwards.hs
+++ b/0.2/Control/Applicative/Backwards.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE CPP #-}
 
 #ifndef HASKELL98
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 # if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE Safe #-}
 # elif __GLASGOW_HASKELL__ >= 702
@@ -33,9 +35,50 @@ import Control.Applicative
 import Data.Foldable
 import Data.Traversable
 
+#ifndef HASKELL98
+# ifdef GENERIC_DERIVING
+import Generics.Deriving.Base
+# elif __GLASGOW_HASKELL__ >= 702
+import GHC.Generics
+# endif
+#endif
+
 -- | The same functor, but with an 'Applicative' instance that performs
 -- actions in the reverse order.
 newtype Backwards f a = Backwards { forwards :: f a }
+
+#ifndef HASKELL98
+# if __GLASGOW_HASKELL__ >= 702 || defined(GENERIC_DERIVING)
+-- Generic(1) instances for Backwards
+instance Generic (Backwards f a) where
+  type Rep (Backwards f a) = D1 D1'Backwards (C1 C1_0'Backwards (S1 S1_0_0'Backwards (Rec0 (f a))))
+  from (Backwards x) = M1 (M1 (M1 (K1 x)))
+  to (M1 (M1 (M1 (K1 x)))) = Backwards x
+
+instance Generic1 (Backwards f) where
+  type Rep1 (Backwards f) = D1 D1'Backwards (C1 C1_0'Backwards (S1 S1_0_0'Backwards (Rec1 f)))
+  from1 (Backwards x) = M1 (M1 (M1 (Rec1 x)))
+  to1 (M1 (M1 (M1 x))) = Backwards (unRec1 x)
+
+data D1'Backwards
+data C1_0'Backwards
+data S1_0_0'Backwards
+
+instance Datatype D1'Backwards where
+  datatypeName _ = "Backwards"
+  moduleName _ = "Control.Applicative.Backwards"
+#  if MIN_VERSION_base(4,7,0)
+  isNewtype _ = True
+#  endif
+
+instance Constructor C1_0'Backwards where
+  conName _ = "Backwards"
+  conIsRecord _ = True
+
+instance Selector S1_0_0'Backwards where
+  selName _ = "forwards"
+# endif
+#endif
 
 instance (Eq1 f) => Eq1 (Backwards f) where
     liftEq eq (Backwards x) (Backwards y) = liftEq eq x y
@@ -62,6 +105,8 @@ instance (Show1 f, Show a) => Show (Backwards f a) where showsPrec = showsPrec1
 instance (Functor f) => Functor (Backwards f) where
     fmap f (Backwards a) = Backwards (fmap f a)
     {-# INLINE fmap #-}
+    x <$ Backwards a = Backwards (x <$ a)
+    {-# INLINE (<$) #-}
 
 -- | Apply @f@-actions in the reverse order.
 instance (Applicative f) => Applicative (Backwards f) where
@@ -69,6 +114,16 @@ instance (Applicative f) => Applicative (Backwards f) where
     {-# INLINE pure #-}
     Backwards f <*> Backwards a = Backwards (a <**> f)
     {-# INLINE (<*>) #-}
+#if MIN_VERSION_base(4,10,0)
+    liftA2 f (Backwards m) (Backwards n) = Backwards $ liftA2 (flip f) n m
+    {-# INLINE liftA2 #-}
+#endif
+#if MIN_VERSION_base(4,2,0)
+    Backwards xs *> Backwards ys = Backwards (ys <* xs)
+    {-# INLINE (*>) #-}
+    Backwards ys <* Backwards xs = Backwards (xs *> ys)
+    {-# INLINE (<*) #-}
+#endif
 
 -- | Try alternatives in the same order as @f@.
 instance (Alternative f) => Alternative (Backwards f) where

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,14 @@
+0.7 [????.??.??]
+----------------
+* Backport changes from `transformers-0.6.*`:
+  * Remove the long-deprecated `selectToCont` function from
+    `Control.Monad.Trans.Select`.
+  * Backport various `Generic`, `Generic1`, and `Data` instances.
+  * Backport `handleE`, `tryE`, and `finallyE` to `Control.Monad.Trans.Except`.
+  * Backport explicit implementations of `(<$)`, `liftA2`, `(*>)`, and `(<*)`
+    for `Control.Applicative.Backwards`.
+  * Backport a lazier implementation of `(<*>)` for `Control.Applicative.Lift`.
+
 0.6.6 [2020.09.30]
 ------------------
 * Add `FunctorClassesDefault`, an adapter newtype suitable for `DerivingVia`,

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,7 +1,8 @@
+distribution:           bionic
 no-tests-no-benchmarks: False
 jobs:                   2
 install-dependencies:   False
-irc-channels:           irc.freenode.org#haskell-lens
+-- irc-channels:           irc.freenode.org#haskell-lens
 irc-if-in-origin-repo:  True
 
 constraint-set no-mtl

--- a/tests/transformers-compat-tests.cabal
+++ b/tests/transformers-compat-tests.cabal
@@ -49,7 +49,7 @@ test-suite spec
                       , hspec            >= 2     && < 3
                       , QuickCheck       >= 2     && < 3
                       , tagged           >= 0.7   && < 1
-                      , transformers     >= 0.2   && < 0.6
+                      , transformers     >= 0.2   && < 0.7
                       , transformers-compat
   build-tool-depends:   hspec-discover:hspec-discover >= 2 && < 3
   hs-source-dirs:       .

--- a/transformers-compat.cabal
+++ b/transformers-compat.cabal
@@ -1,6 +1,6 @@
 name:          transformers-compat
 category:      Compatibility
-version:       0.6.6
+version:       0.7
 license:       BSD3
 cabal-version: >= 1.10
 license-file:  LICENSE
@@ -97,7 +97,7 @@ library
     -- These are all transformers versions we support.
     -- each flag below splits this interval into two parts.
     -- flag-true parts are mutually exclusive, so at least one have to be on.
-    transformers >= 0.2 && <0.6
+    transformers >= 0.2 && <0.7
   if !impl(ghc >= 8.0)
     build-depends: fail == 4.9.*
 


### PR DESCRIPTION
This backports a variety of changes from the `transformers-0.6.*` series, including one breaking change (removing the deprecating `selectToCont` function). For the full details, consult the `CHANGELOG`.

Fixes #48.