### PR TITLE
Make it compile with MicroHs

### DIFF
--- a/transformers-compat.cabal
+++ b/transformers-compat.cabal
@@ -108,7 +108,7 @@ library
     build-depends: transformers >= 0.5.3
 
   -- other flags
-  if flag(generic-deriving)
+  if impl(ghc) && flag(generic-deriving)
     hs-source-dirs: generics
     exposed-modules:
       Data.Functor.Classes.Generic


### PR DESCRIPTION
Only enable the `generic-deriving` part on GHC, since MicroHs doesn't properly support generics yet. Also update the links (`git://` isn't supported anymore).